### PR TITLE
Fix move tree / board desync causing crashes on variation navigation

### DIFF
--- a/chess-game/game.py
+++ b/chess-game/game.py
@@ -111,7 +111,17 @@ class GameFrame(QFrame):
                 self.moves_record.update_moves_record()
 
                 QApplication.processEvents()
-                
+
+    def sync_board_to_tree(self):
+        """Rebuild the physical board to match wherever self.move_tree
+        currently points. Needed after move_up()/move_down(), since those
+        only swap which tree node is "current" without touching the board.
+        """
+        self.board.previous_board = self.board.board.copy()
+        self.board.board = self.move_tree.get_board()
+        self.board.uncheck_all()
+        self.board.update_pieces(self.board.board)
+
     def mousePressEvent(self, event: QMouseEvent):
         global_pos = self.mapToGlobal(event.pos())
 
@@ -142,9 +152,9 @@ class GameFrame(QFrame):
                         self.move_tree.move_forward()
                     elif self.move_tree.has_variant():
                         variant = self.move_tree.get_variant()
-                        if variant.get_next_move() == the_move:
+                        if variant.get_current_move() == the_move:
                             self.move_tree = self.move_tree.move_down()
-                            self.move_tree.move_forward()
+                            self.sync_board_to_tree()
 
                     else:
                         print('zrup variant')
@@ -176,7 +186,8 @@ class GameFrame(QFrame):
                     print('KONIEC WARIANTU')
                     mama = self.move_tree.move_up()
                     if mama:
-                        self.move_tree = mama 
+                        self.move_tree = mama
+                        self.sync_board_to_tree()
             else:
                 print('PUSTY MOVESTACK')
             print(self.move_tree._current_move)
@@ -194,12 +205,17 @@ class GameFrame(QFrame):
         elif event.key() == Qt.Key.Key_Down:
             print("D")
             print(self.move_tree.get_string_repr())
+            child = self.move_tree.move_down()
+            if child:
+                self.move_tree = child
+                self.sync_board_to_tree()
         
         elif event.key() == Qt.Key.Key_Up:
             print("U")
             mama = self.move_tree.move_up()
             if mama:
                 self.move_tree = mama 
+                self.sync_board_to_tree()
                 
         elif event.key() == Qt.Key.Key_E:
             self.thread.started.emit()

--- a/chess-game/move_tree.py
+++ b/chess-game/move_tree.py
@@ -149,3 +149,15 @@ class MoveTree(MoveTreeABC):
 
     def get_variant(self) -> MoveTreeABC:
         return self._alt_line.get(self._current_move)
+    
+    def get_board(self) -> chess.Board:
+        """Reconstruct the actual board position for this node.
+
+        Starts from this node's stored base position (the board as it was
+        when this line/variation began) and replays its own main line up
+        to (and including) the current move pointer.
+        """
+        board = self._board.copy()
+        for move in self._main_line[: self._current_move + 1]:
+            board.push(move)
+        return board


### PR DESCRIPTION
- MoveTree.get_board(): new method to reconstruct a node's actual board position from its stored base + main line, since nodes only tracked moves, not synced board state
- game.py: add sync_board_to_tree() helper, called after move_up() in both the Left-arrow-at-start-of-variant case and the Up key handler, so the physical board matches whichever tree node becomes current (previously only the tree pointer moved, board didn't)
- game.py: fix variant-matching in mousePressEvent -- was comparing against variant.get_next_move() (one move ahead of the variant's own pointer) instead of variant.get_current_move(), so re-clicking an existing variant's first move failed to match and silently desynced tree/board instead of just descending into it
- game.py: Key_Down previously only logged the tree string repr and never actually navigated; now calls move_down() + resyncs the board so users can actually descend back into a variation

Verified manually: single and nested variations, multiple independent variants at different points in the same line, full Left/Right/Up/Down traversal in all directions with no crashes.