### PR TITLE
Show moves in the history panel for manually played moves

### DIFF
--- a/chess-game/game.py
+++ b/chess-game/game.py
@@ -162,8 +162,8 @@ class GameFrame(QFrame):
                         self.move_tree = self.move_tree.move_down()
                     print("Move tree has variant:", self.move_tree.has_variant())
                     print("Move tree:", self.move_tree.id)
+                    self.moves_record.update_moves_record()
                 
-                # self.moves_record.update_moves_record()
 
             self.board.previous_sq_idx = square_index
         else:


### PR DESCRIPTION
update_moves_record() was called from import_pgn() but the equivalent call in mousePressEvent was commented out and mis-indented (sitting outside the 'if self.board.move_made' block), so manually played moves never appeared in the moves history panel.

Note: this does not fix the panel's handling of variations -- it's still ply-indexed and append-only, so playing into or navigating between variants still produces a garbled/incorrect display. Tracked as a separate follow-up.