### PR TITLE
Support multiple sibling variations, add click-to-jump in moves panel

### DIFF
--- a/chess-game/game.py
+++ b/chess-game/game.py
@@ -41,6 +41,7 @@ class GameFrame(QFrame):
 
         self.moves_record = MovesRecord(self)
         self.moves_record.setFixedSize(300, 700)
+        self.moves_record.on_move_clicked = self.jump_to_move
         
         self.move_tree: MoveTree = MoveTree(self.board.board)
 
@@ -121,6 +122,13 @@ class GameFrame(QFrame):
         self.board.board = self.move_tree.get_board()
         self.board.uncheck_all()
         self.board.update_pieces(self.board.board)
+    
+    def jump_to_move(self, node, move_index):
+        node._current_move = move_index
+        node.select_path_to_root()
+        self.move_tree = node
+        self.sync_board_to_tree()
+        self.moves_record.render_from_tree(self.move_tree)
 
     def mousePressEvent(self, event: QMouseEvent):
         global_pos = self.mapToGlobal(event.pos())
@@ -144,24 +152,25 @@ class GameFrame(QFrame):
                 self.board.move_piece(square_index)
                 if self.board.move_made:
                     the_move = self.board.board.peek()
-                    print(f"Move: {the_move},   Next move: {self.move_tree.get_next_move()}")
                     if self.move_tree.get_next_move() is None:
-                        print('idz glowna sciezkom')
                         self.move_tree.add_main(the_move)
                     elif self.move_tree.get_next_move() == the_move:
                         self.move_tree.move_forward()
-                    elif self.move_tree.has_variant():
-                        variant = self.move_tree.get_variant()
-                        if variant.get_current_move() == the_move:
+                    else:
+                        matched_index = None
+                        for i, sibling in enumerate(self.move_tree.get_variants()):
+                            if sibling.get_current_move() == the_move:
+                                matched_index = i
+                                break
+
+                        if matched_index is not None:
+                            self.move_tree.select_variant(matched_index)
                             self.move_tree = self.move_tree.move_down()
                             self.sync_board_to_tree()
+                        else:
+                            self.move_tree.add_variant(the_move, self.board.previous_board)
+                            self.move_tree = self.move_tree.move_down()
 
-                    else:
-                        print('zrup variant')
-                        self.move_tree.add_variant(the_move, self.board.previous_board)
-                        self.move_tree = self.move_tree.move_down()
-                    print("Move tree has variant:", self.move_tree.has_variant())
-                    print("Move tree:", self.move_tree.id)
                     self.moves_record.render_from_tree(self.move_tree)
                 
 
@@ -179,9 +188,13 @@ class GameFrame(QFrame):
                     self.board.uncheck_all()
                     self.board.previous_board = self.board.board.copy()
                     self.board.board.pop()
-                    
-                    # self.board.move_made = True
                     self.board.update_pieces(self.board.board)
+
+                    if self.move_tree._current_move == -1:
+                        parent = self.move_tree.move_up()
+                        if parent:
+                            self.move_tree = parent
+
                     self.moves_record.render_from_tree(self.move_tree)
                 else:
                     print('KONIEC WARIANTU')
@@ -207,9 +220,9 @@ class GameFrame(QFrame):
         
         elif event.key() == Qt.Key.Key_Down:
             print("D")
-            print(self.move_tree.get_string_repr())
             child = self.move_tree.move_down()
             if child:
+                child._current_move = 0
                 self.move_tree = child
                 self.sync_board_to_tree()
                 self.moves_record.render_from_tree(self.move_tree)

--- a/chess-game/info.py
+++ b/chess-game/info.py
@@ -6,11 +6,13 @@ from PyQt6.QtWidgets import (
     QHeaderView,
     QAbstractItemView,
     QTextEdit,
+    QTextBrowser,
 )
 from PyQt6.QtGui import QColor, QPainter, QFont
-from PyQt6.QtCore import Qt, QRect, QObject, pyqtSignal
+from PyQt6.QtCore import Qt, QRect, QObject, QEvent, pyqtSignal
 import chess
 import chess.engine
+import re
 
 from utils import sigmoid
 
@@ -25,21 +27,30 @@ class MyQTableWidget(QTableWidget):
         current_value = self.verticalScrollBar().value()
         self.verticalScrollBar().setValue(current_value - delta)
 
+class MovesBrowser(QTextBrowser):
+    pass
+
 
 class MovesRecord(QWidget):
     def __init__(self, parent):
         super().__init__()
         self.board_frame = parent.board
+        self.on_move_clicked = None
+        self._targets = {}
+        self._lines = []
+        self._active_anchor = None
 
         self.setStyleSheet("background-color: #363636")
 
-        self.text_edit = QTextEdit()
+        self.text_edit = MovesBrowser()
+        self.text_edit.setOpenLinks(False)
         self.text_edit.setReadOnly(True)
         self.text_edit.setFrameStyle(0)
         self.text_edit.setStyleSheet(
-            "QTextEdit {background-color: #363636; color: #f6f6f6; border: 0px;}"
+            "QTextBrowser {background-color: #363636; color: #f6f6f6; border: 0px;}"
         )
         self.text_edit.setFont(QFont("Menlo", 14))
+        self.text_edit.anchorClicked.connect(self._on_anchor_clicked)
 
         vbox_layout = QVBoxLayout()
         vbox_layout.addWidget(self.text_edit)
@@ -48,18 +59,42 @@ class MovesRecord(QWidget):
         self.setLayout(vbox_layout)
 
     def render_from_tree(self, move_tree):
-        lines = move_tree.get_root().render_outline()
+        self._targets = {}
+        self._lines = move_tree.get_root().render_outline(self._targets)
+
+        self._active_anchor = None
+        if move_tree._current_move >= 0:
+            for anchor_id, (node, idx) in self._targets.items():
+                if node is move_tree and idx == move_tree._current_move:
+                    self._active_anchor = anchor_id
+                    break
+
         html_lines = []
-        for depth, text in lines:
+        for depth, html in self._lines:
             margin = depth * 20
-            html_lines.append(
-                f'<div style="margin-left: {margin}px;">{text}</div>'
+            styled_html = re.sub(
+                r'href="(\d+)" style="[^"]*"',
+                lambda m: f'href="{m.group(1)}" style="{self._style_for(m.group(1))}"',
+                html,
             )
+            html_lines.append(f'<div style="margin-left: {margin}px;">{styled_html}</div>')
         self.text_edit.setHtml("".join(html_lines))
         self.text_edit.verticalScrollBar().setValue(
             self.text_edit.verticalScrollBar().maximum()
         )
 
+    def _style_for(self, anchor_id):
+        styles = ["color:#f6f6f6", "text-decoration:none", "padding:1px 3px", "border-radius:3px"]
+        if anchor_id == self._active_anchor:
+            styles += ["background-color:#0f6e56", "color:#eafff6"]
+        return ";".join(styles)
+
+    def _on_anchor_clicked(self, url):
+        anchor_id = url.toString()
+        target = self._targets.get(anchor_id)
+        if target and self.on_move_clicked:
+            node, move_index = target
+            self.on_move_clicked(node, move_index)
 
 class EvaluationBar(QWidget):
     def __init__(self, parent):

--- a/chess-game/move_tree.py
+++ b/chess-game/move_tree.py
@@ -46,10 +46,6 @@ class MoveTreeABC(ABC):
         pass
 
     @abstractmethod
-    def get_string_repr(self) -> str:
-        pass
-
-    @abstractmethod
     def get_variant(self) -> MoveTreeABC:
         pass
 
@@ -58,7 +54,8 @@ class MoveTree(MoveTreeABC):
     def __init__(self, board: chess.Board, parent=None, id: int = 0) -> None:
         self._parent: MoveTree = parent
         self._main_line: List[chess.Move] = []  # lewo prawo szczala
-        self._alt_line: Dict[int, MoveTree] = {}  # gura dul szczala
+        self._alt_line: Dict[int, List[MoveTree]] = {}  # move index -> list of sibling variations
+        self._selected_variant: Dict[int, int] = {}  # move index -> index into that list, "currently active" sibling
         self._current_move: int = -1
         self._board: chess.Board = board.copy()
         self.id = id
@@ -78,7 +75,7 @@ class MoveTree(MoveTreeABC):
         return move
 
     def move_down(self) -> MoveTreeABC:
-        return self._alt_line.get(self._current_move)
+        return self.get_variant()
 
     def move_up(self) -> MoveTreeABC:
         return self._parent
@@ -88,25 +85,45 @@ class MoveTree(MoveTreeABC):
         self._current_move = len(self._main_line) - 1
 
     def add_variant(self, move: chess.Move, board: chess.Board) -> None:
+        siblings = self._alt_line.setdefault(self._current_move, [])
+
+        for i, sibling in enumerate(siblings):
+            if sibling.get_current_move() == move:
+                # This exact variation already exists -- just select it
+                # rather than creating a duplicate.
+                self._selected_variant[self._current_move] = i
+                return
+
         variant_board = board.copy()
-        # print("MY PARENT ", self._parent)
-        # if self._parent:
-        #     print("MY PARENT ID ", self._parent.id)
-        
-        # print("MY ID ", self.id)
-        # print('CURRENT VARINT IN THIS MOVE IF EXISTS: ', self._alt_line.get(self._current_move))
-        # for key, item in self._alt_line.items():
-        #     print('MOVE ', key,  ' VARIANT ', item)
-        if self._alt_line.get(self._current_move) is None:
-            mt= MoveTree(
-                parent=self, board=variant_board, id=self.id+1
-            )
-            # print('NEW WARIANT: ', mt, ' in MOVE ', self._current_move)
-            self._alt_line[self._current_move] = mt
-            self._alt_line[self._current_move].add_main(move)
+        mt = MoveTree(parent=self, board=variant_board, id=self.id + 1)
+        mt.add_main(move)
+        siblings.append(mt)
+        self._selected_variant[self._current_move] = len(siblings) - 1
+
+    def get_variants(self) -> List["MoveTree"]:
+        return self._alt_line.get(self._current_move, [])
 
     def has_variant(self) -> bool:
-        return self._alt_line.get(self._current_move) is not None
+        return bool(self.get_variants())
+
+    def select_variant(self, sibling_index: int) -> None:
+        """Mark which sibling variation is 'active' at the current move,
+        so keyboard navigation (move_down) follows it."""
+        self._selected_variant[self._current_move] = sibling_index
+    
+    def select_path_to_root(self) -> None:
+        """Walk up from this node to the root, marking at each parent
+        which child (self, or the ancestor leading to self) is the
+        'selected' sibling at that branch point -- so keyboard
+        navigation stays consistent with wherever you just jumped to."""
+        node = self
+        while node._parent is not None:
+            parent = node._parent
+            for move_index, siblings in parent._alt_line.items():
+                if node in siblings:
+                    parent._selected_variant[move_index] = siblings.index(node)
+                    break
+            node = parent
 
     def get_next_move(self) -> chess.Move:
         print('GET NEXT MOVE CURRENT MOVE', self._current_move)
@@ -123,28 +140,6 @@ class MoveTree(MoveTreeABC):
         if self._current_move >= 0:
             move = self._main_line[self._current_move - 1]
         return move
-
-    def get_string_repr(self) -> str:
-        board = self._board.copy(stack=True)
-        san = []
-
-
-        for i, move in enumerate(self._main_line):
-            if board.turn == chess.WHITE:
-                san.append(f"{board.fullmove_number}. {board.san_and_push(move)}")
-            elif not san:
-                san.append(f"{board.fullmove_number}...{board.san_and_push(move)}")
-            else:
-                san.append(board.san_and_push(move))
-            varanit = self._alt_line.get(i)
-            if varanit:
-                san.append(f"({varanit.get_string_repr()})")
-
-        varanit = self._alt_line.get(-1)
-        if varanit:
-            san.insert(1, f"({varanit.get_string_repr()})") 
-        
-        return " ".join(san)
     
     def get_root(self) -> "MoveTree":
         node = self
@@ -153,7 +148,11 @@ class MoveTree(MoveTreeABC):
         return node
 
     def get_variant(self) -> MoveTreeABC:
-        return self._alt_line.get(self._current_move)
+        siblings = self.get_variants()
+        if not siblings:
+            return None
+        idx = min(self._selected_variant.get(self._current_move, 0), len(siblings) - 1)
+        return siblings[idx]
     
     def get_board(self) -> chess.Board:
         """Reconstruct the actual board position for this node.
@@ -167,10 +166,16 @@ class MoveTree(MoveTreeABC):
             board.push(move)
         return board
 
-    def render_outline(self, depth: int = 0) -> list:
-        """Render this node and its variations as a list of (depth, text)
+    def render_outline(self, targets: dict, depth: int = 0) -> list:
+        """Render this node and its variations as a list of (depth, html)
         lines, in the lichess/chess.com style: variations get their own
-        indented line(s), the parent line continues below.
+        indented line(s), the parent line continues below. Multiple
+        sibling variations at the same branch point are rendered one
+        after another at the same depth, not nested inside each other.
+
+        `targets` is a dict mutated in place: anchor id (str) -> (node,
+        move_index), so the UI layer can map a click back to an exact
+        position to jump to.
         """
         lines = []
         board = self._board.copy(stack=True)
@@ -181,23 +186,33 @@ class MoveTree(MoveTreeABC):
                 lines.append((depth, " ".join(buffer)))
                 buffer.clear()
 
-        for i, move in enumerate(self._main_line):
-            if board.turn == chess.WHITE:
-                buffer.append(f"{board.fullmove_number}. {board.san_and_push(move)}")
-            elif not buffer:
-                buffer.append(f"{board.fullmove_number}...{board.san_and_push(move)}")
-            else:
-                buffer.append(board.san_and_push(move))
+        def make_anchor(node, move_index, san):
+            anchor_id = str(len(targets))
+            targets[anchor_id] = (node, move_index)
+            return f'<a href="{anchor_id}" style="color:#f6f6f6; text-decoration:none;">{san}</a>'
 
-            variant = self._alt_line.get(i)
-            if variant:
+        for i, move in enumerate(self._main_line):
+            turn_is_white = board.turn == chess.WHITE
+            fullmove_number = board.fullmove_number
+            san = board.san_and_push(move)
+            move_html = make_anchor(self, i, san)
+
+            if turn_is_white:
+                buffer.append(f"{fullmove_number}. {move_html}")
+            elif not buffer:
+                buffer.append(f"{fullmove_number}...{move_html}")
+            else:
+                buffer.append(move_html)
+
+            siblings = self._alt_line.get(i, [])
+            if siblings:
                 flush()
-                lines.extend(variant.render_outline(depth + 1))
+                for sibling in siblings:
+                    lines.extend(sibling.render_outline(targets, depth + 1))
 
         flush()
 
-        variant_before_first_move = self._alt_line.get(-1)
-        if variant_before_first_move:
-            lines.extend(variant_before_first_move.render_outline(depth + 1))
+        for sibling in self._alt_line.get(-1, []):
+            lines.extend(sibling.render_outline(targets, depth + 1))
 
         return lines


### PR DESCRIPTION
Data model (move_tree.py):
- _alt_line changes from {index: MoveTree} to {index: [MoveTree, ...]} -- a branch point can now hold multiple sibling variations, not just one. Previously, playing a second different move at an existing branch point silently did nothing (add_variant's guard blocked it), which desynced the board from the tree and crashed on the next navigation keypress.
- add_variant: searches existing siblings for an exact match before creating a new one (avoids duplicates), otherwise appends a new sibling and marks it selected
- get_variants()/select_variant() added; get_variant()/move_down() now resolve to whichever sibling is currently selected at that branch point
- render_outline() rewritten to: (a) accept a "targets" dict it populates with anchor-id -> (node, move_index) for every rendered move, enabling click-to-jump; (b) render each sibling at a branch point on its own line at the same depth, instead of only ever showing one
- Removed get_string_repr() (dead code, superseded by render_outline and incompatible with the new list-based _alt_line -- was crashing on Down navigation)

UI (info.py):
- MovesRecord's panel is now a QTextBrowser rendering render_outline's HTML anchors; clicking a move calls back into game.py to jump straight to that exact tree node/position
- The move matching the tree's current position is highlighted (teal, matching the board's own highlight color)
- Attempted continuous hover-preview highlighting via several Qt event mechanisms (mouseMoveEvent, eventFilter+MouseMove, eventFilter+ HoverMove) -- none reliably fired without a mouse button held, for reasons not fully root-caused. Dropped in favor of the click + active-highlight behavior only, which works reliably.

Navigation fixes (game.py):
- mousePressEvent: matching an existing variant only checked the currently selected sibling, not all siblings -- playing a second, different move at an existing branch point silently desynced the board from the tree instead of creating a new sibling. Now searches all siblings for a match before falling back to creating a new one.
- Key_Down: now resets the entering variant's position to its first move (child._current_move = 0) rather than resuming wherever that variant was last left -- avoids landing deep inside a variant unexpectedly after Up/Down.
- Key_Left: when a backward step lands exactly on a node's own start (_current_move == -1), immediately reattach to the parent node in the same keypress, instead of requiring an extra Left press before the parent's highlight/state caught up (board was already correct, only the tree pointer and panel highlight lagged one keypress behind).

Verified manually: two distinct siblings at one branch point (no silent desync), click-to-jump across siblings and across depths, Up/Down/Left sequences that previously required workarounds, deep nested variation entry/exit repeated multiple times.