### PR TITLE
Auto-evaluate position after every move and navigation, off the UI thread

### DIFF
--- a/chess-game/game.py
+++ b/chess-game/game.py
@@ -7,7 +7,7 @@ from PyQt6.QtWidgets import (
     QApplication,
 )
 from PyQt6.QtGui import QMouseEvent
-from PyQt6.QtCore import Qt, QRect, QThread
+from PyQt6.QtCore import Qt, QRect, QThread, pyqtSignal
 import chess
 import chess.engine
 import chess.pgn
@@ -21,6 +21,8 @@ GAMES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "game
 
 
 class GameFrame(QFrame):
+    request_evaluation = pyqtSignal(object)
+
     def __init__(self, parent):
         super().__init__(parent)
 
@@ -50,11 +52,11 @@ class GameFrame(QFrame):
         self.thread: QThread = QThread(self)
         self.chess_engine.moveToThread(self.thread)
 
-        # Connect signals and slots
-        self.thread.started.connect(
-            lambda: self.chess_engine.evaluate(self.board.board)
-        )
+        self.request_evaluation.connect(self.chess_engine.evaluate)
+
         self.chess_engine.evaluation_result.connect(self.handle_evaluation_result)
+        self._engine_busy = False
+        self._eval_pending = False
         self.thread.finished.connect(self.thread.quit)
 
         # Right side panel
@@ -89,13 +91,27 @@ class GameFrame(QFrame):
         main_widget.setLayout(main_layout)
         self.setLayout(main_layout)
         self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+    
+    def request_eval(self):
+        if self._engine_busy:
+            self._eval_pending = True
+            return
+        self._engine_busy = True
+        self.request_evaluation.emit(self.board.board.copy())
 
-    def handle_evaluation_result(self, result):
-        self.evaluation_bar.update_engine_evaluation(result)
-        if not self.board.board.is_checkmate():
-            self.engine_lines.update_engine_lines(result)
-        else:
-            self.engine_lines.table_widget.clearContents()
+    def handle_evaluation_result(self, board, result):
+        try:
+            if board.fen() == self.board.board.fen():
+                self.evaluation_bar.update_engine_evaluation(result)
+                if not board.is_checkmate():
+                    self.engine_lines.update_engine_lines(result, board)
+                else:
+                    self.engine_lines.table_widget.clearContents()
+        finally:
+            self._engine_busy = False
+            if self._eval_pending:
+                self._eval_pending = False
+                self.request_eval()
 
     def import_pgn(self, pgn_path):
         with open(pgn_path) as pgn:
@@ -112,6 +128,7 @@ class GameFrame(QFrame):
                 self.moves_record.render_from_tree(self.move_tree)
 
                 QApplication.processEvents()
+            self.request_eval()
 
     def sync_board_to_tree(self):
         """Rebuild the physical board to match wherever self.move_tree
@@ -129,6 +146,7 @@ class GameFrame(QFrame):
         self.move_tree = node
         self.sync_board_to_tree()
         self.moves_record.render_from_tree(self.move_tree)
+        self.request_eval()
 
     def mousePressEvent(self, event: QMouseEvent):
         global_pos = self.mapToGlobal(event.pos())
@@ -172,6 +190,7 @@ class GameFrame(QFrame):
                             self.move_tree = self.move_tree.move_down()
 
                     self.moves_record.render_from_tree(self.move_tree)
+                    self.request_eval()
                 
 
             self.board.previous_sq_idx = square_index
@@ -196,6 +215,7 @@ class GameFrame(QFrame):
                             self.move_tree = parent
 
                     self.moves_record.render_from_tree(self.move_tree)
+                    self.request_eval()
                 else:
                     print('KONIEC WARIANTU')
                     mama = self.move_tree.move_up()
@@ -203,6 +223,7 @@ class GameFrame(QFrame):
                         self.move_tree = mama
                         self.sync_board_to_tree()
                         self.moves_record.render_from_tree(self.move_tree)
+                        self.request_eval()
             else:
                 print('PUSTY MOVESTACK')
             print(self.move_tree._current_move)
@@ -217,6 +238,7 @@ class GameFrame(QFrame):
                 self.board.move_made = True
                 self.board.update_pieces(self.board.board)
                 self.moves_record.render_from_tree(self.move_tree)
+                self.request_eval()
         
         elif event.key() == Qt.Key.Key_Down:
             print("D")
@@ -226,6 +248,7 @@ class GameFrame(QFrame):
                 self.move_tree = child
                 self.sync_board_to_tree()
                 self.moves_record.render_from_tree(self.move_tree)
+                self.request_eval()
         
         elif event.key() == Qt.Key.Key_Up:
             print("U")
@@ -234,6 +257,7 @@ class GameFrame(QFrame):
                 self.move_tree = mama 
                 self.sync_board_to_tree()
                 self.moves_record.render_from_tree(self.move_tree)
+                self.request_eval()
                 
         elif event.key() == Qt.Key.Key_E:
-            self.thread.started.emit()
+            self.request_eval()

--- a/chess-game/info.py
+++ b/chess-game/info.py
@@ -227,7 +227,7 @@ class EngineLines(QWidget):
         item.setFont(QFont("Menlo", 12))
         self.table_widget.setItem(row, col, item)
 
-    def update_engine_lines(self, evaluation):
+    def update_engine_lines(self, evaluation, board):
         self.table_widget.setColumnCount(2)
         for idx, eval_dict in enumerate(evaluation[:3]):
             score = eval_dict["score"].white()
@@ -242,7 +242,7 @@ class EngineLines(QWidget):
             line = eval_dict.get("pv", "")
             # Consider only lines longer than two moves unless its forced mate
             if len(line) > 2 or score.mate():
-                line_str = self.board_frame.board.variation_san(line)
+                line_str = board.variation_san(line)
                 self.add_table_item(
                     line_str,
                     idx,
@@ -251,10 +251,9 @@ class EngineLines(QWidget):
                 )
         self.update()
 
-
 class ChessEngine(QObject):
-    evaluation_result = pyqtSignal(list)
-    
+    evaluation_result = pyqtSignal(object, list)
+
     engine = chess.engine.SimpleEngine.popen_uci(
         "/opt/homebrew/bin/stockfish"
     )
@@ -263,4 +262,4 @@ class ChessEngine(QObject):
         info = self.engine.analyse(
             board, chess.engine.Limit(depth=16), multipv=5
         )
-        self.evaluation_result.emit(info)
+        self.evaluation_result.emit(board, info)

--- a/chess-game/main.py
+++ b/chess-game/main.py
@@ -36,4 +36,5 @@ if __name__ == "__main__":
     window.show()
     # Start the engine thread when the application starts
     window.game_frame.thread.start()
+    window.game_frame.request_eval()
     app.exec()


### PR DESCRIPTION
Previously, evaluation only ran once on launch and on manual E key presses -- moving pieces or navigating did not trigger a fresh evaluation, so the eval bar/engine lines silently went stale after the first move.

Wiring the trigger in naively surfaced two real bugs:

1. The engine call was actually running on the main GUI thread the entire time, not the background QThread it was moved to. The original connection used a lambda: self.thread.started.connect(lambda: self.chess_engine.evaluate(...)) Qt can only dispatch a signal to the correct thread when the receiver is an identifiable bound method on a QObject; a bare lambda has no thread affinity Qt can detect, so it silently ran synchronously on the caller's thread instead of being queued to the engine's thread. This blocked the UI on every evaluation, which was very noticeable once evaluation started firing on every move instead of just at launch.

   Fixed by adding a real signal (request_evaluation) connected directly to ChessEngine.evaluate (a bound QObject method Qt can correctly attribute to the background thread).

2. Making evaluation asynchronous introduced a race: the engine could still be analysing an old position when a new move changed the board, and by the time results arrived, chess.Board.variation_san would throw IllegalMoveError trying to replay old suggested moves against a position that had since moved past them, since the same live board object was being read across threads.

   Fixed by:
   - always emitting a snapshot (self.board.board.copy()) rather than the live board object, including the initial evaluation kicked off from main.py at launch
   - ChessEngine.evaluate emits the board it evaluated back alongside the result, and handle_evaluation_result discards results whose board no longer matches the current position (fen comparison)
   - a busy/pending flag pair (request_eval) so that moves made while an evaluation is already in flight don't spawn overlapping engine requests -- only the latest position once the engine frees up gets evaluated, matching how other review tools skip evaluating positions you've already moved past. main.py's initial call now also goes through request_eval() rather than emitting the signal directly, so it participates in the same busy-flag guard as every other call site.
   - handle_evaluation_result wrapped in try/finally so the busy flag always clears even if something in the update path throws, rather than permanently wedging future evaluations

Verified manually: rapid move sequences no longer block the UI or crash, eval settles on the final position after a burst of moves, manual E key still works, PGN import evaluates once at the end rather than on every replayed move.