### PR TITLE
Import PGN variations, not just the mainline; auto-scroll panel to active move

### DIFF
--- a/chess-game/game.py
+++ b/chess-game/game.py
@@ -113,22 +113,49 @@ class GameFrame(QFrame):
                 self._eval_pending = False
                 self.request_eval()
 
+    def _import_variations(self, pgn_node, tree_node):
+        """Recursively walk a python-chess GameNode tree and rebuild it
+        as our own MoveTree, preserving every variation from the PGN
+        file (not just the mainline)."""
+        variations = pgn_node.variations
+        if not variations:
+            return
+
+        # Sidelines must be added while tree_node's current position
+        # still matches pgn_node (i.e. before the mainline move below
+        # advances it), since add_variant keys off the current position.
+        sideline_children = []
+        for child in variations[1:]:
+            board_before = pgn_node.board()
+            tree_node.add_variant(child.move, board_before)
+            sideline_children.append((child, tree_node.get_variant()))
+
+        mainline_child = variations[0]
+        tree_node.add_main(mainline_child.move)
+
+        for child, variant_node in sideline_children:
+            self._import_variations(child, variant_node)
+
+        self._import_variations(mainline_child, tree_node)
+
     def import_pgn(self, pgn_path):
         with open(pgn_path) as pgn:
             game = chess.pgn.read_game(pgn)
-            self.board.board = game.board()
-            for move in game.mainline_moves():
-                self.move_tree.add_main(move)
 
-                self.board.previous_board = self.board.board.copy()
+        if game is None:
+            print(f"Could not read a game from {pgn_path}")
+            return
 
-                self.board.board.push(move)
-                self.board.move_made = True
-                self.board.update_pieces(self.board.board)
-                self.moves_record.render_from_tree(self.move_tree)
+        self.board.board = game.board()
+        self.move_tree = MoveTree(self.board.board)
+        self._import_variations(game, self.move_tree)
 
-                QApplication.processEvents()
-            self.request_eval()
+        if self.move_tree._main_line:
+            self.move_tree._current_move = len(self.move_tree._main_line) - 1
+
+        self.sync_board_to_tree()
+        self.moves_record.render_from_tree(self.move_tree)
+        self.request_eval()
 
     def sync_board_to_tree(self):
         """Rebuild the physical board to match wherever self.move_tree
@@ -199,7 +226,7 @@ class GameFrame(QFrame):
 
     def keyPressEvent(self, event):
         if event.key() == Qt.Key.Key_Control:
-            self.import_pgn(os.path.join(GAMES_DIR, "TALHAA79_vs_SzachowySmoluch_2024.03.01.pgn"))
+            self.import_pgn(os.path.join(GAMES_DIR, "lichess_pgn_2024.02.04_Quadrogroth_vs_Ka2sa.uTuihpsM.pgn"))
 
         if event.key() == Qt.Key.Key_Left:
             if self.board.board.move_stack:

--- a/chess-game/info.py
+++ b/chess-game/info.py
@@ -8,8 +8,8 @@ from PyQt6.QtWidgets import (
     QTextEdit,
     QTextBrowser,
 )
-from PyQt6.QtGui import QColor, QPainter, QFont
-from PyQt6.QtCore import Qt, QRect, QObject, QEvent, pyqtSignal
+from PyQt6.QtGui import QColor, QPainter, QFont, QTextCursor
+from PyQt6.QtCore import Qt, QRect, QObject, QEvent, QTimer, pyqtSignal
 import chess
 import chess.engine
 import re
@@ -79,10 +79,31 @@ class MovesRecord(QWidget):
             )
             html_lines.append(f'<div style="margin-left: {margin}px;">{styled_html}</div>')
         self.text_edit.setHtml("".join(html_lines))
-        self.text_edit.verticalScrollBar().setValue(
-            self.text_edit.verticalScrollBar().maximum()
-        )
+        self._scroll_to_active()
 
+    def _scroll_to_active(self):
+        if self._active_anchor is None:
+            self.text_edit.verticalScrollBar().setValue(0)
+            return
+
+        doc = self.text_edit.document()
+        block = doc.begin()
+        found = False
+        while block.isValid():
+            it = block.begin()
+            while not it.atEnd():
+                frag = it.fragment()
+                fmt = frag.charFormat()
+                if fmt.isAnchor() and self._active_anchor in fmt.anchorNames():
+                    found = True
+                    cursor = QTextCursor(doc)
+                    cursor.setPosition(frag.position())
+                    self.text_edit.setTextCursor(cursor)
+                    self.text_edit.ensureCursorVisible()
+                    return
+                it += 1
+            block = block.next()
+    
     def _style_for(self, anchor_id):
         styles = ["color:#f6f6f6", "text-decoration:none", "padding:1px 3px", "border-radius:3px"]
         if anchor_id == self._active_anchor:

--- a/chess-game/move_tree.py
+++ b/chess-game/move_tree.py
@@ -189,7 +189,7 @@ class MoveTree(MoveTreeABC):
         def make_anchor(node, move_index, san):
             anchor_id = str(len(targets))
             targets[anchor_id] = (node, move_index)
-            return f'<a href="{anchor_id}" style="color:#f6f6f6; text-decoration:none;">{san}</a>'
+            return f'<a name="{anchor_id}" href="{anchor_id}" style="color:#f6f6f6; text-decoration:none;">{san}</a>'
 
         for i, move in enumerate(self._main_line):
             turn_is_white = board.turn == chess.WHITE


### PR DESCRIPTION
PGN import (game.py):
- import_pgn rewritten: previously only walked game.mainline_moves(), silently dropping every annotated variation in the source file -- a significant gap for a tool whose whole point is reviewing games, since most annotated/engine-reviewed PGNs have sidelines.
- New _import_variations() recursively walks python-chess's GameNode tree (node.variations[0] is the mainline continuation, any further entries are sidelines) and rebuilds it as our own MoveTree via the existing add_main/add_variant, so imported variations are fully navigable and clickable exactly like ones built by hand.
- Import now discards whatever game was previously in progress and starts a fresh MoveTree at the PGN's starting position, rather than bolting the imported moves onto whatever you'd already played.
- Replaced the old move-by-move animated replay (which doesn't map cleanly onto tree-shaped import) with building the whole tree instantly and jumping straight to the end of the mainline -- you can navigate anywhere via arrow keys or the moves panel immediately after import.
- Ctrl now loads a real annotated lichess PGN (with several actual variations) as the demo file, instead of a plain game with none.
- Guards against chess.pgn.read_game() returning None for an empty or unparseable file, instead of crashing.

Moves panel (info.py, move_tree.py):
- Each rendered move's anchor now also carries a  attribute (previously only , which is enough for click-to-jump but not for Qt's own anchor-lookup/scroll APIs to find it)
- MovesRecord._scroll_to_active(): walks the document's text fragments to find the active move's anchor by name, positions a cursor there, and calls ensureCursorVisible() -- so navigating to any point in a long imported game (including sidelines) keeps the active move in view. Previously the panel always scrolled to the bottom, which only happened to look correct while playing forward and was wrong for backward/click navigation.

Verified manually against a real annotated lichess PGN with multiple nested variations: full variation tree imports correctly (spot checked against the source file's parenthesized sidelines), click- to-jump works throughout, and the panel correctly scrolls to show the active move at both the start and end of a long game.