### PR TITLE
Code cleanup: remove debug prints, fix ABC drift, portable engine path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+CHESS_ENGINE_PATH=/opt/homebrew/bin/stockfish

--- a/chess-game/game.py
+++ b/chess-game/game.py
@@ -12,6 +12,9 @@ import chess
 import chess.engine
 import chess.pgn
 import os
+import logging
+
+logger = logging.getLogger(__name__)
 
 from board import ChessBoard
 from info import MovesRecord, EvaluationBar, EngineLines, ChessEngine
@@ -222,7 +225,7 @@ class GameFrame(QFrame):
 
             self.board.previous_sq_idx = square_index
         else:
-            print("Mouse click is outside the frame's visible area")
+            logger.debug("Mouse click is outside the frame's visible area")
 
     def keyPressEvent(self, event):
         if event.key() == Qt.Key.Key_Control:
@@ -244,7 +247,7 @@ class GameFrame(QFrame):
                     self.moves_record.render_from_tree(self.move_tree)
                     self.request_eval()
                 else:
-                    print('KONIEC WARIANTU')
+                    logger.debug("End of variation, moving up to parent line")
                     mama = self.move_tree.move_up()
                     if mama:
                         self.move_tree = mama
@@ -252,8 +255,7 @@ class GameFrame(QFrame):
                         self.moves_record.render_from_tree(self.move_tree)
                         self.request_eval()
             else:
-                print('PUSTY MOVESTACK')
-            print(self.move_tree._current_move)
+                logger.debug("Move stack is empty, nothing to go back to")
 
 
         elif event.key() == Qt.Key.Key_Right:
@@ -268,7 +270,6 @@ class GameFrame(QFrame):
                 self.request_eval()
         
         elif event.key() == Qt.Key.Key_Down:
-            print("D")
             child = self.move_tree.move_down()
             if child:
                 child._current_move = 0
@@ -278,7 +279,6 @@ class GameFrame(QFrame):
                 self.request_eval()
         
         elif event.key() == Qt.Key.Key_Up:
-            print("U")
             mama = self.move_tree.move_up()
             if mama:
                 self.move_tree = mama 

--- a/chess-game/info.py
+++ b/chess-game/info.py
@@ -16,6 +16,36 @@ import re
 
 from utils import sigmoid
 
+import os
+import shutil
+
+
+def find_engine_path() -> str:
+    """Resolve the UCI engine executable path.
+
+    Resolution order:
+    1. CHESS_ENGINE_PATH environment variable (explicit override).
+    2. A "stockfish" binary discoverable on PATH.
+    3. Raise a clear, actionable error instead of crashing on import.
+    """
+    env_path = os.environ.get("CHESS_ENGINE_PATH")
+    if env_path:
+        if os.path.isfile(env_path):
+            return env_path
+        raise FileNotFoundError(
+            f"CHESS_ENGINE_PATH is set to '{env_path}' but no file exists there."
+        )
+
+    found = shutil.which("stockfish")
+    if found:
+        return found
+
+    raise FileNotFoundError(
+        "Could not locate a Stockfish executable. Install Stockfish and make "
+        "sure it is on your PATH, or set the CHESS_ENGINE_PATH environment "
+        "variable to point at the executable."
+    )
+
 
 class MyQTableWidget(QTableWidget):
     def __init__(self):
@@ -250,6 +280,7 @@ class EngineLines(QWidget):
 
     def update_engine_lines(self, evaluation, board):
         self.table_widget.setColumnCount(2)
+        self.table_widget.clearContents()
         for idx, eval_dict in enumerate(evaluation[:3]):
             score = eval_dict["score"].white()
             score_str = self.get_score_str(score)
@@ -272,12 +303,15 @@ class EngineLines(QWidget):
                 )
         self.update()
 
+
 class ChessEngine(QObject):
     evaluation_result = pyqtSignal(object, list)
 
-    engine = chess.engine.SimpleEngine.popen_uci(
-        "/opt/homebrew/bin/stockfish"
-    )
+    def __init__(self, engine_path: str = None):
+        super().__init__()
+        self.engine = chess.engine.SimpleEngine.popen_uci(
+            engine_path or find_engine_path()
+        )
 
     def evaluate(self, board):
         info = self.engine.analyse(

--- a/chess-game/main.py
+++ b/chess-game/main.py
@@ -1,6 +1,9 @@
 import sys
+from dotenv import load_dotenv
 from PyQt6.QtWidgets import QApplication, QMainWindow, QStackedWidget
 from PyQt6.QtGui import QCloseEvent
+
+load_dotenv()
 
 from game import GameFrame
 

--- a/chess-game/move_tree.py
+++ b/chess-game/move_tree.py
@@ -26,11 +26,23 @@ class MoveTreeABC(ABC):
         pass
 
     @abstractmethod
-    def add_variant(self, move: chess.Move) -> None:
+    def add_variant(self, move: chess.Move, board: chess.Board) -> None:
+        pass
+
+    @abstractmethod
+    def get_variants(self) -> List["MoveTree"]:
         pass
 
     @abstractmethod
     def has_variant(self) -> bool:
+        pass
+
+    @abstractmethod
+    def select_variant(self, sibling_index: int) -> None:
+        pass
+
+    @abstractmethod
+    def select_path_to_root(self) -> None:
         pass
 
     @abstractmethod
@@ -49,11 +61,23 @@ class MoveTreeABC(ABC):
     def get_variant(self) -> MoveTreeABC:
         pass
 
+    @abstractmethod
+    def get_root(self) -> "MoveTree":
+        pass
+
+    @abstractmethod
+    def get_board(self) -> chess.Board:
+        pass
+
+    @abstractmethod
+    def render_outline(self, targets: dict, depth: int = 0) -> list:
+        pass
+
 
 class MoveTree(MoveTreeABC):
     def __init__(self, board: chess.Board, parent=None, id: int = 0) -> None:
         self._parent: MoveTree = parent
-        self._main_line: List[chess.Move] = []  # lewo prawo szczala
+        self._main_line: List[chess.Move] = []  # moves along this line (left/right navigation)
         self._alt_line: Dict[int, List[MoveTree]] = {}  # move index -> list of sibling variations
         self._selected_variant: Dict[int, int] = {}  # move index -> index into that list, "currently active" sibling
         self._current_move: int = -1
@@ -126,7 +150,6 @@ class MoveTree(MoveTreeABC):
             node = parent
 
     def get_next_move(self) -> chess.Move:
-        print('GET NEXT MOVE CURRENT MOVE', self._current_move)
         move = None
         if self._current_move < len(self._main_line) - 1:
             move = self._main_line[self._current_move + 1]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ PyQt6==6.6.1
 PyQt6-Qt6==6.6.2
 PyQt6-sip==13.6.0
 python-chess==1.999
+python-dotenv


### PR DESCRIPTION
move_tree.py:
- Removed a debug print in get_next_move() that fired unconditionally on every single call, including during normal navigation
- Translated the last remaining Polish comment
- MoveTreeABC was out of sync with what MoveTree actually implements -- several methods added this session (get_variants, select_variant, select_path_to_root, get_root, get_board, render_outline) weren't declared, and add_variant's abstract signature didn't match the real one (missing the board parameter). Brought the interface back in line with the implementation.

game.py:
- Replaced remaining print() debugging (KONIEC WARIANTU, PUSTY MOVESTACK, bare D/U key prints, mouse-outside-board message) with logging.debug calls, or removed entirely where the print wasn't paired with useful context (the unconditional current_move print after every Left press)

info.py:
- ChessEngine's Stockfish path was hardcoded to a personal absolute path evaluated at class-definition time -- same structural issue as the very first bug fixed this project, just re-introduced with a different hardcoded path. Moved engine startup into __init__ and added find_engine_path(), which resolves the path via the CHESS_ENGINE_PATH environment variable or a PATH lookup, raising a clear error instead of crashing on import if neither is found.
- EngineLines.update_engine_lines() didn't clear the table before writing new rows -- if a new evaluation produced fewer qualifying PV lines than the previous one, stale rows from the old evaluation stayed visible. Added clearContents() at the start of every update.

main.py:
- Loads a .env file (via python-dotenv) before constructing the game, so CHESS_ENGINE_PATH can be configured persistently via .env instead of only through a shell-exported environment variable each session.

Added .env.example documenting CHESS_ENGINE_PATH for anyone else cloning the repo, and added python-dotenv to requirements.txt. .env itself is gitignored so personal paths are never committed.

Verified manually: normal play, variation navigation, and engine evaluation all still work correctly; engine path now correctly reads from .env, and correctly raises a clear error when pointed at a nonexistent path rather than silently falling back or crashing unhelpfully.