### PR TITLE
Add promotion piece selection dialog

### DIFF
--- a/chess-game/board.py
+++ b/chess-game/board.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 import chess
 
 from piece import PieceItem
+from promotion_dialog import PromotionDialog
 
 
 class ChessBoard(QFrame):
@@ -152,7 +153,11 @@ class ChessBoard(QFrame):
                 self.previous_sq_idx in self.possible_promotions.keys()
                 and square_index in self.possible_promotions[self.previous_sq_idx]
             ):
-                move = chess.Move(self.previous_sq_idx, square_index, promotion=5)
+                dialog = PromotionDialog(self.board.turn, self)
+                dialog.exec()
+                move = chess.Move(
+                    self.previous_sq_idx, square_index, promotion=dialog.selected_piece
+                )
             else:
                 move = chess.Move(self.previous_sq_idx, square_index)
             self.previous_board = self.board.copy()

--- a/chess-game/promotion_dialog.py
+++ b/chess-game/promotion_dialog.py
@@ -1,0 +1,47 @@
+import os
+
+from PyQt6.QtWidgets import QDialog, QHBoxLayout, QPushButton
+from PyQt6.QtGui import QPixmap, QIcon
+from PyQt6.QtCore import QSize
+import chess
+
+ASSETS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "assets")
+
+
+class PromotionDialog(QDialog):
+    PROMOTION_PIECES = [chess.QUEEN, chess.ROOK, chess.BISHOP, chess.KNIGHT]
+
+    def __init__(self, color: bool, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Choose promotion")
+        self.setModal(True)
+        self.selected_piece = chess.QUEEN  # fallback if closed without a choice
+
+        layout = QHBoxLayout()
+        layout.setContentsMargins(10, 10, 10, 10)
+        layout.setSpacing(8)
+
+        for piece_type in self.PROMOTION_PIECES:
+            button = QPushButton()
+            button.setFixedSize(70, 70)
+            pixmap = QPixmap(
+                os.path.join(
+                    ASSETS_DIR,
+                    "pieces",
+                    "{}{}.png".format(
+                        "w" if color else "b", chess.piece_symbol(piece_type)
+                    ),
+                )
+            )
+            button.setIcon(QIcon(pixmap))
+            button.setIconSize(QSize(60, 60))
+            button.clicked.connect(
+                lambda checked, p=piece_type: self._choose(p)
+            )
+            layout.addWidget(button)
+
+        self.setLayout(layout)
+
+    def _choose(self, piece_type):
+        self.selected_piece = piece_type
+        self.accept()


### PR DESCRIPTION
Previously, pawn promotion always silently auto-promoted to queen (a hardcoded magic number, promotion=5, with no UI to choose otherwise) -- a real functional gap, since under-promotion to a knight, rook, or bishop is sometimes the correct or only winning move in real games.

- New promotion_dialog.py: a small modal QDialog showing four buttons (queen, rook, bishop, knight) using the same piece images already in assets/pieces/, colored to match whichever side is promoting (self.board.turn). Falls back to queen if the dialog is closed without a selection.
- board.py: move_piece() now opens this dialog the moment a promotion move is detected, and uses the chosen piece type to build the move instead of the hardcoded promotion=5.

Verified manually: promotion works for both colors with correct piece-color icons, promoting to a non-queen piece works correctly including inside variations (different variants promoting to different pieces at the same branch point), and closing the dialog without choosing falls back to queen rather than crashing.