### PR TITLE
Render moves panel as a lichess/chess.com-style two-column table

### DIFF
--- a/chess-game/info.py
+++ b/chess-game/info.py
@@ -90,7 +90,7 @@ class MovesRecord(QWidget):
 
     def render_from_tree(self, move_tree):
         self._targets = {}
-        self._lines = move_tree.get_root().render_outline(self._targets)
+        rows = move_tree.get_root().render_table(self._targets)
 
         self._active_anchor = None
         if move_tree._current_move >= 0:
@@ -99,16 +99,35 @@ class MovesRecord(QWidget):
                     self._active_anchor = anchor_id
                     break
 
-        html_lines = []
-        for depth, html in self._lines:
-            margin = depth * 20
-            styled_html = re.sub(
+        def style(html):
+            if html is None:
+                return "&nbsp;"
+            return re.sub(
                 r'href="(\d+)" style="[^"]*"',
                 lambda m: f'href="{m.group(1)}" style="{self._style_for(m.group(1))}"',
                 html,
             )
-            html_lines.append(f'<div style="margin-left: {margin}px;">{styled_html}</div>')
-        self.text_edit.setHtml("".join(html_lines))
+
+        html_parts = ['<table width="100%" style="border-collapse: collapse;">']
+        for row in rows:
+            if row["type"] == "row":
+                html_parts.append(
+                    '<tr>'
+                    f'<td width="40" style="color:#8a8a8a; padding: 2px 4px; white-space: nowrap;">{row["move_number"]}.</td>'
+                    f'<td width="120" style="padding: 2px 4px;">{style(row["white"])}</td>'
+                    f'<td width="120" style="padding: 2px 4px;">{style(row["black"])}</td>'
+                    '</tr>'
+                )
+            else:  # variation
+                variation_html = " ".join(style(html) for depth, html in row["lines"])
+                html_parts.append(
+                    '<tr>'
+                    f'<td></td><td colspan="2" style="color:#9a9a9a; padding: 2px 4px 2px 20px;">{variation_html}</td>'
+                    '</tr>'
+                )
+        html_parts.append("</table>")
+
+        self.text_edit.setHtml("".join(html_parts))
         self._scroll_to_active()
 
     def _scroll_to_active(self):

--- a/chess-game/move_tree.py
+++ b/chess-game/move_tree.py
@@ -73,6 +73,10 @@ class MoveTreeABC(ABC):
     def render_outline(self, targets: dict, depth: int = 0) -> list:
         pass
 
+    @abstractmethod
+    def render_table(self, targets: dict) -> list:
+        pass
+
 
 class MoveTree(MoveTreeABC):
     def __init__(self, board: chess.Board, parent=None, id: int = 0) -> None:
@@ -239,3 +243,66 @@ class MoveTree(MoveTreeABC):
             lines.extend(sibling.render_outline(targets, depth + 1))
 
         return lines
+
+    def render_table(self, targets: dict) -> list:
+        """Render this node's own main line as chess.com/lichess-style
+        rows: (move_number, White cell, Black cell). Variations
+        branching off are rendered using the existing render_outline()
+        and inserted as a full-width row directly beneath the row they
+        branch from, rather than being spliced mid-row.
+        """
+        rows = []
+        board = self._board.copy(stack=True)
+        current_row = None
+
+        def make_anchor(move_index, san):
+            anchor_id = str(len(targets))
+            targets[anchor_id] = (self, move_index)
+            return f'<a name="{anchor_id}" href="{anchor_id}" style="color:#f6f6f6; text-decoration:none;">{san}</a>'
+
+        def flush_row():
+            nonlocal current_row
+            if current_row is not None:
+                rows.append(current_row)
+                current_row = None
+
+        for i, move in enumerate(self._main_line):
+            turn_is_white = board.turn == chess.WHITE
+            fullmove_number = board.fullmove_number
+            san = board.san_and_push(move)
+            move_html = make_anchor(i, san)
+
+            if turn_is_white:
+                flush_row()
+                current_row = {
+                    "type": "row",
+                    "move_number": fullmove_number,
+                    "white": move_html,
+                    "black": None,
+                }
+            else:
+                if current_row is None:
+                    current_row = {
+                        "type": "row",
+                        "move_number": fullmove_number,
+                        "white": None,
+                        "black": None,
+                    }
+                current_row["black"] = move_html
+
+            siblings = self._alt_line.get(i, [])
+            if siblings:
+                flush_row()
+                for sibling in siblings:
+                    rows.append(
+                        {"type": "variation", "lines": sibling.render_outline(targets, depth=0)}
+                    )
+
+        flush_row()
+
+        for sibling in self._alt_line.get(-1, []):
+            rows.append(
+                {"type": "variation", "lines": sibling.render_outline(targets, depth=0)}
+            )
+
+        return rows


### PR DESCRIPTION
Replaces the flowing indented-text layout (from the earlier tree-outline branch) with a real two-column White/Black table, closer to how lichess and chess.com display move lists.

move_tree.py:
- New render_table(): walks this node's main line and groups moves into (move_number, white, black) rows. When a variation branches off, the current row is flushed, the variation is rendered as its own block (reusing the existing render_outline() unchanged), and a new row picks up the continuation -- so a variation branching right after White's move causes Black's actual reply to start a fresh row with an empty White cell, rather than being spliced into the same row the way lichess does it. That mid-row splicing needs per-ply table cells lichess/chess.com's own data model supports and ours doesn't; breaking into a new row was chosen as a deliberately simpler compromise for this phase.
- Declared render_table on MoveTreeABC to keep the interface in sync.

info.py:
- MovesRecord.render_from_tree rewritten to emit an HTML <table> instead of flowing <div> lines, using render_table's row structure. Empty cells (no Black move yet) render as &nbsp; rather than collapsing to nothing.
- All existing anchor-based machinery (click-to-jump, active-move highlighting via _style_for, scroll-to-active) is reused completely unchanged -- it only depends on named anchors existing somewhere in the document, regardless of whether they're inside a <div> or a <td>.
- Column widths: discovered Qt's rich-text HTML engine silently ignores CSS `width` on <td> (confirmed via inspecting QTextTableFormat's columnWidthConstraints(), which showed VariableLength/0.0 for all columns despite explicit CSS widths) -- it only respects the HTML `width` attribute. Switched from CSS-in-style widths to HTML width attributes for the move-number, White, and Black columns, which produces stable, consistent column boundaries regardless of move text length.
- The move-number column also needed widening (30px -> 40px, plus white-space: nowrap) -- two-digit move numbers were overflowing and wrapping their "." onto a second line within the same narrow cell.

Verified manually: stable column widths across short and long move text, correct move-number rendering at both single- and double-digit counts, variations rendering as clickable indented rows, click-to-jump into variation moves, active-move highlighting, scroll-to-active at both the start and a deep position of a long game, and PGN import with real variations from the existing annotated test file.