### PR TITLE
Fix connector/continuation padding width mismatch

### DIFF
--- a/chess-game/move_tree.py
+++ b/chess-game/move_tree.py
@@ -217,7 +217,7 @@ class MoveTree(MoveTreeABC):
         def flush():
             nonlocal first_line
             if buffer:
-                line_prefix = prefix if first_line else '<span style="display:inline-block; width:22px;"></span>'
+                line_prefix = prefix if first_line else '<span style="display:inline-block; width:28px;"></span>'
                 lines.append((depth, line_prefix + " ".join(buffer)))
                 buffer.clear()
                 first_line = False


### PR DESCRIPTION
flush()'s blank continuation-padding span was still width:22px, a leftover from before the connector spans (child_prefix and both copies in render_table) were bumped to width:28px. This caused any variation whose text wrapped or was interrupted by an internal nested branch to show its continuation line starting 6px left of the connector line above it.

Verified manually: a variation with an internal nested branch now shows its wrapped continuation aligned exactly under the connector line's own text.