### PR TITLE
Code quality cleanup: dedupe connector logic, remove dead code, error handling

### DIFF
--- a/chess-game/game.py
+++ b/chess-game/game.py
@@ -31,8 +31,6 @@ class GameFrame(QFrame):
         super().__init__(parent)
 
         self.parent = parent
-        # self.engine = engine
-        self.popped_moves = []
 
         self.setStyleSheet("background-color: #262626")
 
@@ -158,8 +156,7 @@ class GameFrame(QFrame):
             self.move_tree._current_move = len(self.move_tree._main_line) - 1
 
         self.sync_board_to_tree()
-        self.moves_record.render_from_tree(self.move_tree)
-        self.request_eval()
+        self._on_position_changed()
 
     def sync_board_to_tree(self):
         """Rebuild the physical board to match wherever self.move_tree
@@ -171,13 +168,19 @@ class GameFrame(QFrame):
         self.board.uncheck_all()
         self.board.update_pieces(self.board.board)
     
+    def _on_position_changed(self):
+        """Call after self.move_tree changes (a move was made, or we
+        navigated/jumped elsewhere in the tree) to keep the moves
+        panel and engine evaluation in sync with the new position."""
+        self.moves_record.render_from_tree(self.move_tree)
+        self.request_eval()
+    
     def jump_to_move(self, node, move_index):
         node._current_move = move_index
         node.select_path_to_root()
         self.move_tree = node
         self.sync_board_to_tree()
-        self.moves_record.render_from_tree(self.move_tree)
-        self.request_eval()
+        self._on_position_changed()
 
     def mousePressEvent(self, event: QMouseEvent):
         global_pos = self.mapToGlobal(event.pos())
@@ -220,8 +223,7 @@ class GameFrame(QFrame):
                             self.move_tree.add_variant(the_move, self.board.previous_board)
                             self.move_tree = self.move_tree.move_down()
 
-                    self.moves_record.render_from_tree(self.move_tree)
-                    self.request_eval()
+                    self._on_position_changed()
                 
 
             self.board.previous_sq_idx = square_index
@@ -249,16 +251,14 @@ class GameFrame(QFrame):
                         if parent:
                             self.move_tree = parent
 
-                    self.moves_record.render_from_tree(self.move_tree)
-                    self.request_eval()
+                    self._on_position_changed()
                 else:
                     logger.debug("End of variation, moving up to parent line")
                     mama = self.move_tree.move_up()
                     if mama:
                         self.move_tree = mama
                         self.sync_board_to_tree()
-                        self.moves_record.render_from_tree(self.move_tree)
-                        self.request_eval()
+                        self._on_position_changed()
             else:
                 logger.debug("Move stack is empty, nothing to go back to")
 
@@ -271,8 +271,7 @@ class GameFrame(QFrame):
                 self.board.board.push(popped_move)
                 self.board.move_made = True
                 self.board.update_pieces(self.board.board)
-                self.moves_record.render_from_tree(self.move_tree)
-                self.request_eval()
+                self._on_position_changed()
         
         elif event.key() == Qt.Key.Key_Down:
             child = self.move_tree.move_down()
@@ -280,16 +279,14 @@ class GameFrame(QFrame):
                 child._current_move = 0
                 self.move_tree = child
                 self.sync_board_to_tree()
-                self.moves_record.render_from_tree(self.move_tree)
-                self.request_eval()
+                self._on_position_changed()
         
         elif event.key() == Qt.Key.Key_Up:
             mama = self.move_tree.move_up()
             if mama:
                 self.move_tree = mama 
                 self.sync_board_to_tree()
-                self.moves_record.render_from_tree(self.move_tree)
-                self.request_eval()
+                self._on_position_changed()
                 
         elif event.key() == Qt.Key.Key_E:
             self.request_eval()

--- a/chess-game/info.py
+++ b/chess-game/info.py
@@ -5,7 +5,6 @@ from PyQt6.QtWidgets import (
     QVBoxLayout,
     QHeaderView,
     QAbstractItemView,
-    QTextEdit,
     QTextBrowser,
 )
 from PyQt6.QtGui import QColor, QPainter, QFont, QTextCursor
@@ -18,6 +17,9 @@ from utils import sigmoid
 
 import os
 import shutil
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def find_engine_path() -> str:
@@ -67,7 +69,6 @@ class MovesRecord(QWidget):
         self.board_frame = parent.board
         self.on_move_clicked = None
         self._targets = {}
-        self._lines = []
         self._active_anchor = None
 
         self.setStyleSheet("background-color: #363636")
@@ -356,7 +357,14 @@ class ChessEngine(QObject):
         )
 
     def evaluate(self, board):
-        info = self.engine.analyse(
-            board, chess.engine.Limit(depth=16), multipv=5
-        )
+        try:
+            info = self.engine.analyse(
+                board, chess.engine.Limit(depth=16), multipv=5
+            )
+        except chess.engine.EngineTerminatedError:
+            logger.error("Stockfish process terminated unexpectedly during analysis")
+            return
+        except chess.engine.EngineError as e:
+            logger.error("Stockfish engine error during analysis: %s", e)
+            return
         self.evaluation_result.emit(board, info)

--- a/chess-game/move_tree.py
+++ b/chess-game/move_tree.py
@@ -4,6 +4,14 @@ from typing import Dict, List
 from abc import ABC, abstractmethod
 
 
+def _connector_span(is_last: bool) -> str:
+    """Box-drawing connector for a variation branch: an 'L' shape if
+    this is the last sibling at its branch point, a 'T' shape
+    otherwise. Wrapped in a fixed-width span so it lines up exactly
+    with continuation-line padding regardless of glyph metrics."""
+    connector = "\u2514\u2500" if is_last else "\u251c\u2500"
+    return f'<span style="display:inline-block; width:28px;">{connector}&nbsp;</span>'
+
 class MoveTreeABC(ABC):
     @abstractmethod
     def move_forward(self) -> chess.Move:
@@ -228,8 +236,7 @@ class MoveTree(MoveTreeABC):
             return f'<a name="{anchor_id}" href="{anchor_id}" style="color:#f6f6f6; text-decoration:none;">{san}</a>'
 
         def child_prefix(is_last):
-            connector = "\u2514\u2500" if is_last else "\u251c\u2500"
-            return f'<span style="display:inline-block; width:28px;">{connector}&nbsp;</span>'
+            return _connector_span(is_last)
 
         for i, move in enumerate(self._main_line):
             turn_is_white = board.turn == chess.WHITE
@@ -317,12 +324,12 @@ class MoveTree(MoveTreeABC):
                 flush_row()
                 for j, sibling in enumerate(siblings):
                     is_last = j == len(siblings) - 1
-                    connector = "\u2514\u2500" if is_last else "\u251c\u2500"
-                    prefix = f'<span style="display:inline-block; width:28px;">{connector}&nbsp;</span>'
                     rows.append(
                         {
                             "type": "variation",
-                            "lines": sibling.render_outline(targets, depth=0, prefix=prefix),
+                            "lines": sibling.render_outline(
+                                targets, depth=0, prefix=_connector_span(is_last)
+                            ),
                         }
                     )
 
@@ -331,12 +338,12 @@ class MoveTree(MoveTreeABC):
         root_siblings = self._alt_line.get(-1, [])
         for j, sibling in enumerate(root_siblings):
             is_last = j == len(root_siblings) - 1
-            connector = "\u2514\u2500" if is_last else "\u251c\u2500"
-            prefix = f'<span style="display:inline-block; width:28px;">{connector}&nbsp;</span>'
             rows.append(
                 {
                     "type": "variation",
-                    "lines": sibling.render_outline(targets, depth=0, prefix=prefix),
+                    "lines": sibling.render_outline(
+                        targets, depth=0, prefix=_connector_span(is_last)
+                    ),
                 }
             )
 


### PR DESCRIPTION
move_tree.py:
- Extracted the connector-building logic (box-drawing "L"/"T" shapes wrapped in a fixed-width span) into one shared _connector_span() helper, used by render_outline's child_prefix and both loops in render_table. Previously this was duplicated three times, which is exactly how the width-mismatch bug fixed in the prior commit became possible in the first place -- three copies meant three places that could silently drift out of sync with each other.

info.py:
- Removed self._lines, a leftover attribute from an earlier hover- highlight attempt that was never read anywhere in the current code.
- Removed the unused QTextEdit import (only QTextBrowser is used now).
- ChessEngine.evaluate() now catches EngineTerminatedError and EngineError around the analyse() call, logging and returning instead of raising an unhandled exception on the background thread if Stockfish crashes or dies mid-analysis. The app itself won't crash; evaluation simply stops updating from that point, which is a reasonable degraded state pending a proper "reconnect to engine" feature.

game.py:
- Removed self.popped_moves, an unused leftover from before move_tree existed.
- Added _on_position_changed(), a small helper that calls moves_record.render_from_tree() + request_eval() together. This exact pair was previously duplicated across six call sites (mousePressEvent, import_pgn, jump_to_move, and three branches of keyPressEvent) -- collapsing them into one helper means a future change to "what happens when the position changes" only needs to happen in one place, and a new call site can't accidentally forget one half of the pair.

Verified manually: full regression pass across manual play, variation creation/navigation, click-to-jump, PGN import with variations, and connector rendering -- all behave identically to before, since these changes are refactors/hardening rather than behavior changes.