### PR TITLE
Board UI improvements: coordinates, flip, move hints, captured pieces, check/endgame feedback, engine lines polish

### DIFF
--- a/chess-game/board.py
+++ b/chess-game/board.py
@@ -1,4 +1,5 @@
-from PyQt6.QtWidgets import QFrame, QGridLayout, QWidget
+from PyQt6.QtWidgets import QFrame, QGridLayout, QWidget, QLabel
+from PyQt6.QtCore import Qt
 from collections import defaultdict
 import chess
 
@@ -6,29 +7,58 @@ from piece import PieceItem
 from promotion_dialog import PromotionDialog
 
 
+from PyQt6.QtGui import QPainter, QPen, QColor
+from PyQt6.QtCore import QRectF
+
+class MoveHintWidget(QWidget):
+    def __init__(self, parent, is_capture, size):
+        super().__init__(parent)
+        self.is_capture = is_capture
+        self.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents)
+        self.setFixedSize(size, size)
+
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        color = QColor(0, 0, 0, 60)
+
+        if self.is_capture:
+            pen = QPen(color, 5)
+            painter.setPen(pen)
+            painter.setBrush(Qt.BrushStyle.NoBrush)
+            inset = 3
+            painter.drawEllipse(QRectF(inset, inset, self.width() - inset * 2, self.height() - inset * 2))
+        else:
+            painter.setPen(Qt.PenStyle.NoPen)
+            painter.setBrush(color)
+            painter.drawEllipse(self.rect())
+
 class ChessBoard(QFrame):
     def __init__(self, parent):
         super().__init__(parent)
 
-        self.SQUARE_SIZE = 100
+        self.SQUARE_SIZE = 85
         self.SQUARES_NUMBER = 64
         # self.board = chess.Board("rnbqkbnr/pp1p1ppp/8/2pPp3/8/8/PPP1PPPP/RNBQKBNR w KQkq c6 0 1")
         self.board = chess.Board()
         self.previous_board = None
+        self.flipped = False
 
         self.square_colors = {"light": "#e6e6e6", "dark": "#a6a6a6"}
+        # self.square_colors = {"light": "#d9c9a8", "dark": "#6f6558"}
         self.check_colors = {"light": "#e2514c", "dark": "#d74840"}
         self.highlight_colors = {"light": "#00e6b8", "dark": "#00cca3"}
-        self.secondary_colors = {"frame": "#262626"}
+        self.selected_colors = {"light": "#bcd4e6", "dark": "#8fb8d1"}
 
         self.highlighted_squares = set()
-        self.framed_squares = set()
+        self.selected_squares = set()
         self.checked_squares = set()
         self.previous_sq_idx = None
         self.possible_moves = None
         self.possible_promotions = None
         self.move_made = False
         self.pieces_items = {}
+        self.move_hint_widgets = []
 
         self.setContentsMargins(0, 0, 0, 0)
 
@@ -48,6 +78,47 @@ class ChessBoard(QFrame):
             self.set_square_style(sqr_index)
             col, row = self.get_square_coords(sqr_index)
             self.layout.addWidget(square, row, col)
+            self._add_square_label(square, sqr_index, col, row)
+
+    def _add_square_label(self, square, sqr_index, col, row):
+        file_letter = chess.FILE_NAMES[chess.square_file(sqr_index)]
+        rank_number = chess.RANK_NAMES[chess.square_rank(sqr_index)]
+        color = self.get_square_color(sqr_index)
+        label_color = self.square_colors["dark"] if color == "light" else self.square_colors["light"]
+        label_style = f"color: {label_color}; font-size: 11px; font-weight: bold; background: transparent;"
+
+        # Attach to the true chess rank-1 / a-file squares (not the
+        # flip-adjusted screen position) so labels move to the opposite
+        # screen edge when the board is flipped, rather than staying
+        # pinned to the same physical corner regardless of orientation.
+        if chess.square_rank(sqr_index) == 0:  # rank 1 -- file letter
+            file_label = QLabel(file_letter, square)
+            file_label.setStyleSheet(label_style)
+            file_label.adjustSize()
+            # A 180-degree board flip mirrors BOTH axes within the
+            # square, not just one -- unflipped sits bottom-right,
+            # flipped sits top-left.
+            if self.flipped:
+                x, y = 4, 2
+            else:
+                x = self.SQUARE_SIZE - file_label.width() - 4
+                y = self.SQUARE_SIZE - file_label.height() - 2
+            file_label.move(x, y)
+            file_label.show()
+
+        if chess.square_file(sqr_index) == 0:  # a-file -- rank number
+            rank_label = QLabel(rank_number, square)
+            rank_label.setStyleSheet(label_style)
+            rank_label.adjustSize()
+            # Same 180-degree mirroring -- unflipped sits top-left,
+            # flipped sits bottom-right.
+            if self.flipped:
+                x = self.SQUARE_SIZE - rank_label.width() - 4
+                y = self.SQUARE_SIZE - rank_label.height() - 2
+            else:
+                x, y = 4, 2
+            rank_label.move(x, y)
+            rank_label.show()
 
     def draw_pieces(self):
         for sqr_index in range(self.SQUARES_NUMBER):
@@ -76,9 +147,22 @@ class ChessBoard(QFrame):
                     self.layout.addWidget(piece_label, row, col)
                     self.pieces_items[sqr_index] = piece_label
 
+        self._update_check_highlight(next_board)
+
+    def _update_check_highlight(self, board):
+        self.uncheck_all()
+        if board.is_check():
+            king_square = board.king(board.turn)
+            if king_square is not None:
+                self.set_square_style(king_square, "check")
+                self.checked_squares.add(king_square)
+
     def get_square_coords(self, square_index):
         col = chess.square_file(square_index)
         row = 7 - chess.square_rank(square_index)
+        if self.flipped:
+            col = 7 - col
+            row = 7 - row
         return col, row
 
     def get_square_color(self, square_index):
@@ -88,16 +172,16 @@ class ChessBoard(QFrame):
     def set_square_style(self, square_index, square_style=None):
         square = self.findChild(QWidget, chess.SQUARE_NAMES[square_index])
         color = self.get_square_color(square_index)
-        if square_style == "highlight":
+        if square_style == "selected":
+            style = f"background-color: {self.selected_colors[color]}"
+            self.selected_squares.add(square_index)
+        elif square_style == "highlight":
             if square_index not in self.highlighted_squares:
                 style = f"background-color: {self.highlight_colors[color]}"
                 self.highlighted_squares.add(square_index)
             else:
                 style = f"background-color: {self.square_colors[color]}"
                 self.highlighted_squares.remove(square_index)
-        elif square_style == "frame":
-            style = f'background-color: {self.square_colors[color]}; border: 4px solid {self.secondary_colors["frame"]}'
-            self.framed_squares.add(square_index)
         elif square_style == "check":
             style = f"background-color: {self.check_colors[color]}"
         else:
@@ -105,14 +189,11 @@ class ChessBoard(QFrame):
         square.setStyleSheet(style)
 
     def unhighlight_all(self):
-        for sqr_index in self.highlighted_squares.union(self.framed_squares):
+        for sqr_index in self.highlighted_squares.union(self.selected_squares):
             self.set_square_style(sqr_index)
         self.highlighted_squares = set()
-
-    def unframe_all(self):
-        for sqr_index in self.framed_squares:
-            self.set_square_style(sqr_index)
-        self.framed_squares = set()
+        self.selected_squares = set()
+        self._clear_move_hints()
 
     def uncheck_all(self):
         for sqr_index in self.checked_squares:
@@ -134,15 +215,35 @@ class ChessBoard(QFrame):
     def mouse_position_to_square_index(self, mouse_position):
         col = int(mouse_position.x() // self.SQUARE_SIZE)
         row = 7 - int(mouse_position.y() // self.SQUARE_SIZE)
+        if self.flipped:
+            col = 7 - col
+            row = 7 - row
         square_index = chess.square(col, row)
         return square_index
 
     def draw_possible_moves(self, square_index):
         self.get_possible_moves()
+        self._clear_move_hints()
         if square_index in self.possible_moves:
-            self.set_square_style(square_index, "frame")
+            self.set_square_style(square_index, "selected")
             for sq_idx in self.possible_moves[square_index]:
-                self.set_square_style(sq_idx, "frame")
+                is_capture = self.board.piece_at(sq_idx) is not None
+                self._add_move_hint(sq_idx, is_capture)
+            
+    def _clear_move_hints(self):
+        for widget in self.move_hint_widgets:
+            widget.hide()
+            widget.setParent(None)
+            widget.deleteLater()
+        self.move_hint_widgets = []
+
+    def _add_move_hint(self, square_index, is_capture):
+        square = self.findChild(QWidget, chess.SQUARE_NAMES[square_index])
+        size = self.SQUARE_SIZE if is_capture else self.SQUARE_SIZE // 3
+        hint = MoveHintWidget(square, is_capture, size)
+        hint.move((self.SQUARE_SIZE - size) // 2, (self.SQUARE_SIZE - size) // 2)
+        hint.show()
+        self.move_hint_widgets.append(hint)
 
     def move_piece(self, square_index):
         if (
@@ -166,3 +267,21 @@ class ChessBoard(QFrame):
             self.update_pieces(self.board)
         else:
             self.move_made = False
+    
+    def flip_board(self):
+        self.flipped = not self.flipped
+        self._rebuild_board_ui()
+
+    def _rebuild_board_ui(self):
+        # Remove every existing child widget (squares, labels, pieces)
+        while self.layout.count():
+            item = self.layout.takeAt(0)
+            widget = item.widget()
+            if widget:
+                widget.hide()
+                widget.setParent(None)
+                widget.deleteLater()
+        self.pieces_items = {}
+        self.draw_board()
+        self.draw_pieces()
+        self.update()

--- a/chess-game/captured_tray.py
+++ b/chess-game/captured_tray.py
@@ -1,0 +1,94 @@
+import os
+
+from PyQt6.QtWidgets import QWidget, QLabel, QHBoxLayout, QApplication
+from PyQt6.QtGui import QPixmap
+from PyQt6.QtCore import Qt
+import chess
+
+ASSETS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "assets")
+
+PIECE_VALUES = {chess.PAWN: 1, chess.KNIGHT: 3, chess.BISHOP: 3, chess.ROOK: 5, chess.QUEEN: 9}
+STARTING_COUNTS = {chess.PAWN: 8, chess.KNIGHT: 2, chess.BISHOP: 2, chess.ROOK: 2, chess.QUEEN: 1}
+DISPLAY_ORDER = [chess.PAWN, chess.KNIGHT, chess.BISHOP, chess.ROOK, chess.QUEEN]
+
+
+def compute_captured(board):
+    """Derive captured pieces per side by comparing current piece
+    counts to the starting position. Returns (missing_white,
+    missing_black), each the raw list of piece types that side has
+    lost (not net-cancelled against the opponent)."""
+    missing_white = []
+    missing_black = []
+    for piece_type, starting_count in STARTING_COUNTS.items():
+        white_on_board = len(board.pieces(piece_type, chess.WHITE))
+        black_on_board = len(board.pieces(piece_type, chess.BLACK))
+        missing_white.extend([piece_type] * (starting_count - white_on_board))
+        missing_black.extend([piece_type] * (starting_count - black_on_board))
+    return missing_white, missing_black
+
+
+def material_value(piece_types):
+    return sum(PIECE_VALUES[p] for p in piece_types)
+
+
+class CapturedPiecesTray(QWidget):
+    def __init__(self):
+        super().__init__()
+        self.setFixedHeight(32)
+        self.setStyleSheet("background-color: transparent;")
+
+        self.icon_layout = QHBoxLayout()
+        self.icon_layout.setSpacing(0)
+
+        self.material_label = QLabel("")
+        self.material_label.setStyleSheet(
+            "color: #8a8a8a; font-family: Menlo; font-size: 13px;"
+        )
+
+        outer = QHBoxLayout(self)
+        outer.setContentsMargins(0, 2, 0, 2)
+        outer.addLayout(self.icon_layout)
+        outer.addWidget(self.material_label)
+        outer.addStretch()
+
+    def update_captured(self, captured_types, piece_color, material_lead):
+        while self.icon_layout.count():
+            item = self.icon_layout.takeAt(0)
+            widget = item.widget()
+            if widget:
+                widget.deleteLater()
+
+        sorted_types = sorted(captured_types, key=DISPLAY_ORDER.index)
+
+        previous_type = None
+        for piece_type in sorted_types:
+            icon = QLabel()
+            icon.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
+            icon.setStyleSheet("background: transparent;")
+            pixmap = QPixmap(
+                os.path.join(
+                    ASSETS_DIR,
+                    "pieces",
+                    "{}{}.png".format(
+                        "w" if piece_color else "b", chess.piece_symbol(piece_type)
+                    ),
+                )
+            )
+            device_ratio = QApplication.primaryScreen().devicePixelRatio()
+            target_size = int(24 * device_ratio)
+            scaled = pixmap.scaled(
+                target_size, target_size,
+                Qt.AspectRatioMode.KeepAspectRatio,
+                Qt.TransformationMode.SmoothTransformation,
+            )
+            scaled.setDevicePixelRatio(device_ratio)
+            icon.setPixmap(scaled)
+
+            if previous_type is not None:
+                gap = -14 if piece_type == previous_type else 2
+                self.icon_layout.addSpacing(gap)
+
+            self.icon_layout.addWidget(icon)
+            previous_type = piece_type
+
+        self.material_label.setText(f"+{material_lead}" if material_lead > 0 else "")

--- a/chess-game/game.py
+++ b/chess-game/game.py
@@ -6,6 +6,8 @@ from PyQt6.QtWidgets import (
     QVBoxLayout,
     QApplication,
     QFileDialog,
+    QMessageBox,
+    QProgressBar,
 )
 from PyQt6.QtGui import QMouseEvent
 from PyQt6.QtCore import Qt, QRect, QThread, pyqtSignal
@@ -20,6 +22,7 @@ logger = logging.getLogger(__name__)
 from board import ChessBoard
 from info import MovesRecord, EvaluationBar, EngineLines, ChessEngine
 from move_tree import MoveTree
+from captured_tray import CapturedPiecesTray, compute_captured, material_value
 
 GAMES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "games")
 
@@ -34,17 +37,33 @@ class GameFrame(QFrame):
 
         self.setStyleSheet("background-color: #262626")
 
-        self.evaluation_bar = EvaluationBar(self)
-        self.evaluation_bar.setFixedSize(30, 800)
-
         self.board = ChessBoard(self)
-        self.board.setFixedSize(800, 800)
+        self.board.setFixedSize(680, 680)
+
+        self.evaluation_bar = EvaluationBar(self)
+        self.evaluation_bar.setFixedSize(30, 780)
+
+        self.top_tray = CapturedPiecesTray()
+        self.bottom_tray = CapturedPiecesTray()
+
+        board_column_layout = QVBoxLayout()
+        board_column_layout.setContentsMargins(50, 10, 50, 10)
+        board_column_layout.setSpacing(8)
+        board_column_layout.addWidget(self.top_tray)
+        board_column_layout.addWidget(self.board)
+        board_column_layout.addWidget(self.bottom_tray)
+
+        board_column_widget = QWidget()
+        board_column_widget.setStyleSheet("background-color: #363636;")
+        board_column_widget.setLayout(board_column_layout)
+        board_column_widget.setFixedWidth(680 + 50 + 50)
+        board_column_widget.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
 
         self.engine_lines = EngineLines(self)
         self.engine_lines.setFixedSize(300, 90)
 
         self.moves_record = MovesRecord(self)
-        self.moves_record.setFixedSize(300, 700)
+        self.moves_record.setFixedSize(300, 680)
         self.moves_record.on_move_clicked = self.jump_to_move
         
         self.move_tree: MoveTree = MoveTree(self.board.board)
@@ -61,11 +80,24 @@ class GameFrame(QFrame):
         self._eval_pending = False
         self.thread.finished.connect(self.thread.quit)
 
+        self.thinking_bar = QProgressBar()
+        self.thinking_bar.setRange(0, 0)  # indeterminate mode
+        self.thinking_bar.setFixedHeight(4)
+        self.thinking_bar.setMaximumHeight(4)
+        self.thinking_bar.setTextVisible(False)
+        self.thinking_bar.setStyleSheet(
+            "QProgressBar {background-color: #262626; border: none; margin: 0px; padding: 0px;} "
+            "QProgressBar::chunk {background-color: #5dcaa5;}"
+        )
+
         # Right side panel
         right_vbox_layout = QVBoxLayout()
         right_vbox_layout.setContentsMargins(0, 0, 0, 0)
-        right_vbox_layout.setSpacing(10)
+        right_vbox_layout.setSpacing(0)
         right_vbox_layout.addWidget(self.engine_lines)
+        right_vbox_layout.addSpacing(3)
+        right_vbox_layout.addWidget(self.thinking_bar)
+        right_vbox_layout.addSpacing(3)
         right_vbox_layout.addWidget(self.moves_record)
 
         right_vbox_widget = QWidget()
@@ -79,8 +111,9 @@ class GameFrame(QFrame):
         game_layout.setContentsMargins(0, 0, 0, 0)
         game_layout.setSpacing(10)
         game_layout.addWidget(self.evaluation_bar)
-        game_layout.addWidget(self.board)
+        game_layout.addWidget(board_column_widget)
         game_layout.addWidget(right_vbox_widget)
+        game_layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
         game_widget = QWidget()
         game_widget.setLayout(game_layout)
@@ -88,6 +121,7 @@ class GameFrame(QFrame):
         # Main Layout
         main_layout = QVBoxLayout()
         main_layout.addWidget(game_widget)
+        main_layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
         main_widget = QWidget()
         main_widget.setLayout(main_layout)
@@ -99,6 +133,11 @@ class GameFrame(QFrame):
             self._eval_pending = True
             return
         self._engine_busy = True
+        self.engine_lines.set_thinking(True)
+        self.thinking_bar.setStyleSheet(
+            "QProgressBar {background-color: #262626; border: none; margin: 0px; padding: 0px;} "
+            "QProgressBar::chunk {background-color: #5dcaa5;}"
+        )
         self.request_evaluation.emit(self.board.board.copy())
 
     def handle_evaluation_result(self, board, result):
@@ -111,6 +150,11 @@ class GameFrame(QFrame):
                     self.engine_lines.table_widget.clearContents()
         finally:
             self._engine_busy = False
+            self.engine_lines.set_thinking(False)
+            self.thinking_bar.setStyleSheet(
+                "QProgressBar {background-color: #262626; border: none; margin: 0px; padding: 0px;} "
+                "QProgressBar::chunk {background-color: #262626;}"
+            )
             if self._eval_pending:
                 self._eval_pending = False
                 self.request_eval()
@@ -157,6 +201,23 @@ class GameFrame(QFrame):
 
         self.sync_board_to_tree()
         self._on_position_changed()
+    
+    def new_game(self):
+        reply = QMessageBox.question(
+            self,
+            "New Game",
+            "Start a new game? This will discard the current game and any analysis.",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if reply != QMessageBox.StandardButton.Yes:
+            return
+
+        self.board.board = chess.Board()
+        self.board.flipped = False
+        self.board._rebuild_board_ui()
+        self.move_tree = MoveTree(self.board.board)
+        self._on_position_changed()
 
     def sync_board_to_tree(self):
         """Rebuild the physical board to match wherever self.move_tree
@@ -174,7 +235,27 @@ class GameFrame(QFrame):
         panel and engine evaluation in sync with the new position."""
         self.moves_record.render_from_tree(self.move_tree)
         self.request_eval()
+        self._update_captured_trays()
+
+    def _update_captured_trays(self):
+        missing_white, missing_black = compute_captured(self.board.board)
+        material_lead = material_value(missing_black) - material_value(missing_white)
+        self.top_tray.update_captured(missing_white, chess.WHITE, max(-material_lead, 0))
+        self.bottom_tray.update_captured(missing_black, chess.BLACK, max(material_lead, 0))
     
+    def _check_game_end(self, board):
+        if board.is_checkmate():
+            winner = "White" if not board.turn else "Black"
+            QMessageBox.information(self, "Checkmate", f"Checkmate -- {winner} wins!")
+        elif board.is_stalemate():
+            QMessageBox.information(self, "Stalemate", "Stalemate -- the game is a draw.")
+        elif board.is_insufficient_material():
+            QMessageBox.information(self, "Draw", "Draw -- insufficient material to checkmate.")
+        elif board.can_claim_threefold_repetition():
+            QMessageBox.information(self, "Draw", "Draw by threefold repetition.")
+        elif board.is_seventyfive_moves():
+            QMessageBox.information(self, "Draw", "Draw -- 75 moves without a capture or pawn move.")
+
     def jump_to_move(self, node, move_index):
         node._current_move = move_index
         node.select_path_to_root()
@@ -194,7 +275,6 @@ class GameFrame(QFrame):
             square_index = self.board.mouse_position_to_square_index(local_pos)
 
             if event.buttons() == Qt.MouseButton.RightButton:
-                self.board.unframe_all()
                 self.board.set_square_style(square_index, "highlight")
 
             elif event.buttons() == Qt.MouseButton.LeftButton:
@@ -224,14 +304,14 @@ class GameFrame(QFrame):
                             self.move_tree = self.move_tree.move_down()
 
                     self._on_position_changed()
+                    self._check_game_end(self.board.board)
                 
-
             self.board.previous_sq_idx = square_index
         else:
             logger.debug("Mouse click is outside the frame's visible area")
 
     def keyPressEvent(self, event):
-        if event.key() == Qt.Key.Key_Control:
+        if event.key() == Qt.Key.Key_I:
             file_path, _ = QFileDialog.getOpenFileName(
                 self, "Open PGN", GAMES_DIR, "PGN files (*.pgn);;All files (*)"
             )
@@ -290,3 +370,11 @@ class GameFrame(QFrame):
                 
         elif event.key() == Qt.Key.Key_E:
             self.request_eval()
+        
+        elif event.key() == Qt.Key.Key_F:
+            self.board.flip_board()
+            self.engine_lines.refresh_colors()
+            self.evaluation_bar.update()
+        
+        elif event.key() == Qt.Key.Key_N:
+            self.new_game()

--- a/chess-game/info.py
+++ b/chess-game/info.py
@@ -6,8 +6,10 @@ from PyQt6.QtWidgets import (
     QHeaderView,
     QAbstractItemView,
     QTextBrowser,
+    QGraphicsOpacityEffect,
+    QProgressBar,
 )
-from PyQt6.QtGui import QColor, QPainter, QFont, QTextCursor
+from PyQt6.QtGui import QColor, QPainter, QFont, QTextCursor, QFontMetrics
 from PyQt6.QtCore import Qt, QRect, QObject, QEvent, QTimer, pyqtSignal
 import chess
 import chess.engine
@@ -193,6 +195,7 @@ class MovesRecord(QWidget):
 class EvaluationBar(QWidget):
     def __init__(self, parent):
         super().__init__()
+        self.board_frame = parent.board
         self.centipawns = 0
         self.mate = None
 
@@ -214,6 +217,9 @@ class EvaluationBar(QWidget):
             bar_height = sigmoid(self.centipawns / 100)
         else:
             bar_height = 0 if str(self.mate)[1:2] == "-" else 1
+
+        if self.board_frame.flipped:
+            bar_height = 1 - bar_height
 
         rect = self.rect()
         white_height = int(rect.height() * (bar_height))
@@ -259,8 +265,10 @@ class EvaluationBar(QWidget):
 
 class EngineLines(QWidget):
     def __init__(self, parent):
-        super().__init__()
+        super().__init__(parent)
         self.board_frame = parent.board
+        self._last_evaluation = None
+        self._last_board = None
 
         self.setStyleSheet("background-color: #363636")
 
@@ -302,6 +310,14 @@ class EngineLines(QWidget):
         vbox_layout.setContentsMargins(0, 0, 0, 0)
         self.setLayout(vbox_layout)
 
+    def set_thinking(self, is_thinking):
+        if is_thinking:
+            effect = QGraphicsOpacityEffect()
+            effect.setOpacity(0.4)
+            self.table_widget.setGraphicsEffect(effect)
+        else:
+            self.table_widget.setGraphicsEffect(None)
+
     def get_score_str(self, score):
         if score.score() is not None:
             score_str = str(round(score.score() / 100, 1))
@@ -314,38 +330,80 @@ class EngineLines(QWidget):
             )
         return score_str
 
-    def add_table_item(self, text, row, col, alignment):
+    def add_table_item(self, text, row, col, alignment, color=None, bold=False):
         item = QTableWidgetItem(text)
         item.setTextAlignment(alignment)
-        item.setForeground(QColor("#f6f6f6"))
-        item.setFont(QFont("Menlo", 12))
+        item.setForeground(QColor(color or "#f6f6f6"))
+        font = QFont("Menlo", 12)
+        font.setBold(bold)
+        item.setFont(font)
+        if row % 2 == 1:
+            item.setBackground(QColor("#3d3d3d"))
         self.table_widget.setItem(row, col, item)
 
+    def _color_for_score(self, score):
+        flipped = self.board_frame.flipped
+        mate = score.mate()
+        if mate is not None:
+            favors_bottom = (mate > 0) != flipped
+            return "#5dcaa5" if favors_bottom else "#e2514c"
+        centipawns = score.score()
+        if centipawns is None:
+            return "#f6f6f6"
+        magnitude = min(abs(centipawns) / 300, 1.0)
+        favors_bottom = (centipawns >= 0) != flipped
+        target = "#5dcaa5" if favors_bottom else "#e2514c"
+        return self._blend("#f6f6f6", target, magnitude)
+
+    def _blend(self, base_hex, target_hex, t):
+        base = QColor(base_hex)
+        target = QColor(target_hex)
+        r = int(base.red() + (target.red() - base.red()) * t)
+        g = int(base.green() + (target.green() - base.green()) * t)
+        b = int(base.blue() + (target.blue() - base.blue()) * t)
+        return QColor(r, g, b).name()
+
     def update_engine_lines(self, evaluation, board):
+        self._last_evaluation = evaluation
+        self._last_board = board
         self.table_widget.setColumnCount(2)
         self.table_widget.clearContents()
         for idx, eval_dict in enumerate(evaluation[:3]):
             score = eval_dict["score"].white()
             score_str = self.get_score_str(score)
+            score_color = self._color_for_score(score)
             self.add_table_item(
                 score_str,
                 idx,
                 0,
                 Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignVCenter,
+                color=score_color,
             )
 
             line = eval_dict.get("pv", "")
             # Consider only lines longer than two moves unless its forced mate
             if len(line) > 2 or score.mate():
                 line_str = board.variation_san(line)
+                available_width = self.table_widget.columnWidth(1) - 10
+                metrics = QFontMetrics(QFont("Menlo", 12))
+                elided = metrics.elidedText(
+                    line_str, Qt.TextElideMode.ElideRight, available_width
+                )
                 self.add_table_item(
-                    line_str,
+                    elided,
                     idx,
                     1,
                     Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter,
                 )
         self.update()
 
+    def refresh_colors(self):
+        """Re-render the last known evaluation with the current board
+        orientation's color mapping, without re-querying the engine --
+        flipping the board doesn't change the position, so there's
+        nothing new to evaluate."""
+        if self._last_evaluation is not None:
+            self.update_engine_lines(self._last_evaluation, self._last_board)
 
 class ChessEngine(QObject):
     evaluation_result = pyqtSignal(object, list)
@@ -359,7 +417,7 @@ class ChessEngine(QObject):
     def evaluate(self, board):
         try:
             info = self.engine.analyse(
-                board, chess.engine.Limit(depth=16), multipv=5
+                board, chess.engine.Limit(depth=16), multipv=3
             )
         except chess.engine.EngineTerminatedError:
             logger.error("Stockfish process terminated unexpectedly during analysis")

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd "$(dirname "$0")/chess-game"
+python3 main.py


### PR DESCRIPTION
Board (board.py):
- Coordinate labels (a-h, 1-8) shown at the true chess rank-1/a-file squares, positioned so they correctly move to the opposite screen edge and corner when the board is flipped, rather than staying pinned to a fixed screen position.
- Flip board orientation (F key): get_square_coords and mouse_position_to_square_index both account for self.flipped, and flip_board() rebuilds the whole visual board. Widget removal uses hide()+setParent(None) alongside deleteLater() so old widgets disappear immediately rather than lingering until Qt's event loop gets around to it (was causing a "fog of war" effect where stale squares/pieces only cleared as you interacted with them).
- Move hints: replaced the old plain colored-border "frame" highlight for reachable squares with lichess-style overlays -- a small dot for quiet moves, a ring for captures -- drawn via a custom MoveHintWidget.paintEvent() (QPainter.drawEllipse) rather than Qt stylesheet borders, since QSS border+border-radius on a QWidget renders as four independent segments with visible seams at the corners rather than a true continuous circle.
- Selected piece now gets its own dedicated highlight color/style (selected_colors, distinct from the manual right-click marking system's highlight_colors) so the two are visually and semantically separate.
- King-in-check highlighting actually wired up: the check_colors, checked_squares, and uncheck_all() scaffolding already existed in the codebase but nothing ever called set_square_style(king_sq, "check") -- added _update_check_highlight(), called from update_pieces() (the universal "position changed" hook), so it fires after every move, navigation, and sync.
- Removed now-dead scaffolding: after switching the picked-up-piece highlight from "frame" to "selected", nothing called set_square_style(..., "frame") anymore, so secondary_colors, framed_squares, and unframe_all() were deleted along with the dead branch in set_square_style(); the one remaining caller in game.py's right-click handler was simplified accordingly.

Captured pieces tray (new file, captured_tray.py):
- compute_captured(board) derives captured pieces per side by comparing current piece counts to the starting position (python- chess doesn't track a capture history directly).
- CapturedPiecesTray renders them as small overlapping icons (same visual convention as chess.com: same-type pieces stack tightly, different types get a small gap) plus a "+N" material-lead number next to whichever side is ahead.
- Icons needed WA_TranslucentBackground + a transparent stylesheet to actually respect the source PNGs' real alpha transparency -- a bare QLabel with a pixmap otherwise paints an opaque background first, making transparent pixels show a visible box.
- Icons are rendered at the display's real device pixel ratio then told their logical size via setDevicePixelRatio(), fixing a blur that appeared when scaling directly to logical pixel dimensions on a HiDPI/Retina display.

Layout (game.py):
- Board, evaluation bar, and the moves/engine-lines column are now sized consistently against a single recomputed total height (top tray + spacing + board + spacing + bottom tray + margins), after an earlier attempt to add a colored frame around the board surfaced and then required fixing several um-matched fixed sizes once the frame was reverted.
- The whole game area (eval bar + board + trays + moves panel) is now centered in the window via QLayout.setAlignment(AlignCenter) on both the main layout and the game layout -- previously, maximizing or full-screening the window caused Qt to stretch the gaps between widgets to fill the extra space instead of keeping everything packed together.
- New game (N key): resets the board, move tree, and flip state, behind a QMessageBox confirmation (defaulting to "No") since it's destructive and easy to trigger by accident.
- Checkmate/stalemate/insufficient-material/threefold-repetition/ 75-move-rule messages via QMessageBox, shown only from mousePressEvent right after a move is actually played -- explicitly not called from PGN import, jump_to_move, or arrow-key navigation, so browsing back into a historical game-ending position doesn't repeatedly pop up a dialog.

Engine lines (info.py):
- Eval scores are now color-coded green/red by advantage magnitude, and swap which color means "good" based on board_frame.flipped, so green always means "good for whoever is at the bottom of the board right now" regardless of orientation.
- Long principal variations are elided with QFontMetrics.elidedText() to fit the actual column width (replacing an earlier fixed half- move count), so the display adapts to whatever text actually fits rather than guessing a fixed length.
- Evaluation depth's multipv reduced from 5 to 3, matching the number of lines actually displayed -- Stockfish was computing two full principal variations that were immediately discarded.
- A thinking indicator (dimmed table + a thin indeterminate progress bar between the engine-lines and moves panels) shows while evaluation is in flight. The progress bar is always present in the layout at a fixed height and only toggles its chunk color between visible and background-matching -- an earlier version that show()/hide()'d the bar caused a real, expected layout shift equal to the bar's own height every time it appeared, which felt more jarring in practice than intended; keeping it permanently in the layout eliminates any shift at all.
- Flipping the board (F) re-renders the last cached evaluation through the new color mapping (EngineLines.refresh_colors()/ EvaluationBar.update()) instead of re-querying Stockfish -- the position hasn't changed on a flip, so there's nothing new to evaluate, and re-running the engine only added a confusing delay where the numbers appeared to change when only their color should.

Verified manually: coordinate labels, move hints, selected/check/ manual-marking highlight colors, captured piece tray rendering and contrast, flip orientation (labels, eval bar, and engine-line colors all correctly mirror), centered layout at both small and maximized window sizes, checkmate/draw messages firing only on the ending move itself, and engine-lines color/elision/thinking-indicator behavior -- all alongside a full regression pass of existing functionality (moves, variations, click-to-jump, PGN import, promotion, engine evaluation).