### PR TITLE
Player names, flip-aware trays, scrollbar styling, and several real Qt bugs fixed

### DIFF
--- a/chess-game/captured_tray.py
+++ b/chess-game/captured_tray.py
@@ -1,6 +1,6 @@
 import os
 
-from PyQt6.QtWidgets import QWidget, QLabel, QHBoxLayout, QApplication
+from PyQt6.QtWidgets import QWidget, QLabel, QHBoxLayout, QApplication, QSizePolicy
 from PyQt6.QtGui import QPixmap
 from PyQt6.QtCore import Qt
 import chess
@@ -37,6 +37,12 @@ class CapturedPiecesTray(QWidget):
         self.setFixedHeight(32)
         self.setStyleSheet("background-color: transparent;")
 
+        self.name_label = QLabel("")
+        self.name_label.setStyleSheet(
+            "color: #d0d0d0; font-family: Menlo; font-size: 13px; font-weight: bold;"
+        )
+        self.name_label.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
+
         self.icon_layout = QHBoxLayout()
         self.icon_layout.setSpacing(0)
 
@@ -47,9 +53,15 @@ class CapturedPiecesTray(QWidget):
 
         outer = QHBoxLayout(self)
         outer.setContentsMargins(0, 2, 0, 2)
+        outer.setSpacing(6)
+        outer.addWidget(self.name_label)
         outer.addLayout(self.icon_layout)
         outer.addWidget(self.material_label)
         outer.addStretch()
+
+    def set_name(self, name):
+        self.name_label.setText(name)
+        self.name_label.adjustSize()
 
     def update_captured(self, captured_types, piece_color, material_lead):
         while self.icon_layout.count():

--- a/chess-game/game.py
+++ b/chess-game/game.py
@@ -67,6 +67,13 @@ class GameFrame(QFrame):
         self.moves_record.on_move_clicked = self.jump_to_move
         
         self.move_tree: MoveTree = MoveTree(self.board.board)
+        
+        self.white_name = "White"
+        self.black_name = "Black"
+
+        self._update_captured_trays()
+
+        self._last_top_moves = []
 
         # Create a thread for the engine
         self.chess_engine = ChessEngine()
@@ -151,6 +158,7 @@ class GameFrame(QFrame):
                         line = eval_dict.get("pv", "")
                         if line:
                             top_moves.append(line[0])
+                    self._last_top_moves = top_moves
                     self.board.show_best_move_arrows(top_moves)
                 else:
                     self.engine_lines.table_widget.clearContents()
@@ -199,6 +207,9 @@ class GameFrame(QFrame):
             print(f"Could not read a game from {pgn_path}")
             return
 
+        self.white_name = game.headers.get("White", "White")
+        self.black_name = game.headers.get("Black", "Black")
+
         self.board.board = game.board()
         self.move_tree = MoveTree(self.board.board)
         self._import_variations(game, self.move_tree)
@@ -220,6 +231,8 @@ class GameFrame(QFrame):
         if reply != QMessageBox.StandardButton.Yes:
             return
 
+        self.white_name = "White"
+        self.black_name = "Black"
         self.board.board = chess.Board()
         self.board.flipped = False
         self.board._rebuild_board_ui()
@@ -240,6 +253,7 @@ class GameFrame(QFrame):
         """Call after self.move_tree changes (a move was made, or we
         navigated/jumped elsewhere in the tree) to keep the moves
         panel and engine evaluation in sync with the new position."""
+        self._last_top_moves = []
         self.board.clear_best_move_arrow()
         self.moves_record.render_from_tree(self.move_tree)
         self.request_eval()
@@ -248,8 +262,22 @@ class GameFrame(QFrame):
     def _update_captured_trays(self):
         missing_white, missing_black = compute_captured(self.board.board)
         material_lead = material_value(missing_black) - material_value(missing_white)
-        self.top_tray.update_captured(missing_white, chess.WHITE, max(-material_lead, 0))
-        self.bottom_tray.update_captured(missing_black, chess.BLACK, max(material_lead, 0))
+
+        white_tray_data = (self.white_name, missing_white, chess.WHITE, max(-material_lead, 0))
+        black_tray_data = (self.black_name, missing_black, chess.BLACK, max(material_lead, 0))
+
+        # White sits at the bottom normally, top when flipped -- keep
+        # each tray showing whichever color is actually on that side
+        # of the board right now.
+        top_data, bottom_data = (
+            (black_tray_data, white_tray_data)
+            if self.board.flipped
+            else (white_tray_data, black_tray_data)
+        )
+
+        for tray, (name, missing, color, lead) in ((self.top_tray, top_data), (self.bottom_tray, bottom_data)):
+            tray.set_name(name)
+            tray.update_captured(missing, color, lead)
     
     def _check_game_end(self, board):
         if board.is_checkmate():
@@ -383,6 +411,8 @@ class GameFrame(QFrame):
             self.board.flip_board()
             self.engine_lines.refresh_colors()
             self.evaluation_bar.update()
+            self._update_captured_trays()
+            self.board.show_best_move_arrows(self._last_top_moves)
         
         elif event.key() == Qt.Key.Key_N:
             self.new_game()

--- a/chess-game/info.py
+++ b/chess-game/info.py
@@ -83,6 +83,11 @@ class MovesRecord(QWidget):
         self.text_edit.setFrameStyle(0)
         self.text_edit.setStyleSheet(
             "QTextBrowser {background-color: #363636; color: #f6f6f6; border: 0px;}"
+            "QScrollBar:vertical {background: #363636; width: 8px; margin: 0px;}"
+            "QScrollBar::handle:vertical {background: #5a5a5a; border-radius: 4px; min-height: 20px;}"
+            "QScrollBar::handle:vertical:hover {background: #6e6e6e;}"
+            "QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {height: 0px;}"
+            "QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical {background: none;}"
         )
         self.text_edit.setFont(QFont("Menlo", 14))
         self.text_edit.anchorClicked.connect(self._on_anchor_clicked)
@@ -97,7 +102,8 @@ class MovesRecord(QWidget):
         self._targets = {}
         rows = move_tree.get_root().render_table(self._targets)
 
-        viewport_width = self.text_edit.viewport().width()
+        scrollbar_width = self.text_edit.verticalScrollBar().sizeHint().width()
+        viewport_width = self.text_edit.viewport().width() - scrollbar_width
         move_number_width = 40
         remaining = max(viewport_width - move_number_width, 100)
         column_width = remaining // 2
@@ -147,6 +153,7 @@ class MovesRecord(QWidget):
         previous_scroll = scrollbar.value()
 
         self.text_edit.setHtml("".join(html_parts))
+        self.text_edit.document().setTextWidth(self.text_edit.viewport().width())
 
         scrollbar.setValue(previous_scroll)
         self._scroll_to_active()
@@ -166,15 +173,19 @@ class MovesRecord(QWidget):
                 if fmt.isAnchor() and self._active_anchor in fmt.anchorNames():
                     cursor = QTextCursor(doc)
                     cursor.setPosition(frag.position())
-                    rect = self.text_edit.cursorRect(cursor)
+                    # Trust Qt's own visibility check rather than
+                    # reimplementing it -- ensureCursorVisible() is a
+                    # no-op if the cursor is already visible, so this
+                    # is safe to call unconditionally.
+                    self.text_edit.setTextCursor(cursor)
+                    self.text_edit.ensureCursorVisible()
 
+                    # ensureCursorVisible() only scrolls the minimum
+                    # needed, landing the active line right at the
+                    # viewport's edge -- nudge a bit further so it
+                    # settles in with some breathing room instead.
                     scrollbar = self.text_edit.verticalScrollBar()
-                    visible_top = scrollbar.value()
-                    visible_bottom = visible_top + self.text_edit.viewport().height()
-
-                    if rect.top() < visible_top or rect.bottom() > visible_bottom:
-                        self.text_edit.setTextCursor(cursor)
-                        self.text_edit.ensureCursorVisible()
+                    scrollbar.setValue(min(scrollbar.value() + 24, scrollbar.maximum()))
                     return
                 it += 1
             block = block.next()
@@ -214,27 +225,31 @@ class EvaluationBar(QWidget):
         painter.setRenderHint(QPainter.RenderHint.Antialiasing)
 
         if self.centipawns is not None:
-            bar_height = sigmoid(self.centipawns / 100)
+            white_fraction = sigmoid(self.centipawns / 100)
         else:
-            bar_height = 0 if str(self.mate)[1:2] == "-" else 1
+            # mate encodes mate-in-N for whichever side delivers it;
+            # this fraction still always means "how much of the bar
+            # belongs to White", independent of board orientation.
+            white_fraction = 0.0 if str(self.mate)[1:2] == "-" else 1.0
 
-        if self.board_frame.flipped:
-            bar_height = 1 - bar_height
+        flipped = self.board_frame.flipped
+        bottom_color = Qt.GlobalColor.black if flipped else Qt.GlobalColor.white
+        top_color = Qt.GlobalColor.white if flipped else Qt.GlobalColor.black
+        bottom_fraction = (1 - white_fraction) if flipped else white_fraction
 
         rect = self.rect()
-        white_height = int(rect.height() * (bar_height))
-        black_height = rect.height() - white_height
-        black_rect = rect.adjusted(0, 0, 0, -white_height)
-        white_rect = rect.adjusted(0, black_height, 0, 0)
+        bottom_height = int(rect.height() * bottom_fraction)
+        top_height = rect.height() - bottom_height
+        top_rect = rect.adjusted(0, 0, 0, -bottom_height)
+        bottom_rect = rect.adjusted(0, top_height, 0, 0)
 
-        # Draw the black and white sections
-        painter.fillRect(white_rect, Qt.GlobalColor.white)
-        painter.fillRect(black_rect, Qt.GlobalColor.black)
+        painter.fillRect(bottom_rect, bottom_color)
+        painter.fillRect(top_rect, top_color)
 
         painter.setFont(QFont("Menlo", 12))
 
-        if bar_height >= 0.5:
-            painter.setPen(QColor("black"))
+        if bottom_fraction >= 0.5:
+            text_color = "black" if bottom_color == Qt.GlobalColor.white else "white"
             text_pos = (
                 0,
                 rect.height() - int(1.5 * painter.fontMetrics().height()),
@@ -242,14 +257,15 @@ class EvaluationBar(QWidget):
                 painter.fontMetrics().height(),
             )
         else:
-            painter.setPen(QColor("white"))
+            text_color = "black" if top_color == Qt.GlobalColor.white else "white"
             text_pos = (
                 0,
                 int(0.5 * painter.fontMetrics().height()),
                 rect.width(),
                 painter.fontMetrics().height(),
             )
-        # Draw the evaluation text
+        painter.setPen(QColor(text_color))
+
         if self.centipawns is not None:
             text = f"{abs(self.centipawns / 100):.1f}"
         else:


### PR DESCRIPTION
Player names (game.py, captured_tray.py):
- GameFrame now tracks white_name/black_name, populated from PGN headers on import (defaulting to plain "White"/"Black" for manually-played games and after New Game).
- CapturedPiecesTray shows the name next to that side's captured pieces. The name label's width is sized to its actual text (QSizePolicy.Minimum) rather than a fixed guess, so short and long names both get exactly the space they need.

Flip-aware trays (game.py):
- _update_captured_trays now assigns white/black data to the top/bottom tray based on board.flipped, so captured material and names correctly swap sides when the board orientation changes, instead of being permanently tied to a fixed screen position regardless of which color is actually there.
- Key_F now also calls _update_captured_trays(), since flipping doesn't change the position but does change which tray should show which side.

Moves panel scrollbar (info.py):
- Custom QSS styling for a thin (8px), flat, minimal scrollbar with a subtle rounded handle, replacing Qt's default chunky scrollbar with arrow buttons.

Real bugs found and fixed while polishing the above:

1. Intermittent horizontal scrollbar: column widths were computed from viewport().width() *before* Qt had decided whether a vertical scrollbar was needed for the newly-rendered content -- right at the transition point where a game's move list first grows tall enough to need one, the width calculation used the old (wider) viewport, and the scrollbar then appeared afterward, narrowing the real space just enough to cause overflow. Fixed by always reserving the scrollbar's width in the column calculation, regardless of whether Qt currently thinks one is needed.

2. Autoscroll stopped working partway through long games (confirmed via debug logging: it worked correctly for roughly the first 28 moves, then stopped). Root cause was our own reimplementation of "is the active line currently visible" using cursorRect() and a manual comparison against the scrollbar's visible range -- this became unreliable as the document grew. Replaced with Qt's own ensureCursorVisible(), which already no-ops correctly when nothing needs to move, removing the need to duplicate that logic ourselves at all. A small manual scroll offset is added afterward since ensureCursorVisible() only scrolls the bare minimum needed, which otherwise left the active line sitting right at the viewport edge.

3. Best-move arrows didn't reposition when the board was flipped -- they're computed once when engine results arrive, and flipping doesn't produce new results, so nothing recomputed them against the new coordinate mapping. Fixed by caching the last shown moves (_last_top_moves) and recalling show_best_move_arrows() with the same moves after a flip.

4. The evaluation bar's flip handling was logically wrong, not just visually reversed: it only inverted which fraction of the bar was filled, but always painted White at the bottom regardless of orientation -- so a "mate in 3 for White" could render as if it favored the side now at the bottom, even when that side was Black. Rewritten so "how much of the bar belongs to White" and "which color paints at the bottom" are computed together and consistently, so White's advantage always renders as White's advantage, regardless of which physical end of the bar it currently occupies.

Known issue, not yet reproduced: a captured rook was observed to be completely missing from the board's visual rendering after some sequence of navigation, despite being present in the actual chess.Board state -- moving it manually forced it to reappear. update_pieces() only recreates piece widgets for squares where previous_board and the new board disagree; something in this instance likely left previous_board out of sync with the last real screen state, causing a square that had genuinely changed to be silently skipped. Exact repro steps not yet identified; flagging for future investigation if it recurs.

Verified manually: player names display and default correctly, tray/ name pairs swap sides correctly on flip, scrollbar renders thin and functions correctly with no more intermittent horizontal scrollbar, autoscroll tracks reliably through a full 80+ move imported game with comfortable margin, best-move arrows reposition correctly after flip, and the evaluation bar's colors correctly track material advantage regardless of orientation.