### PR TITLE
Fix moves-panel flicker during navigation; fix PGN import board reset

### DIFF
--- a/chess-game/game.py
+++ b/chess-game/game.py
@@ -224,14 +224,28 @@ class GameFrame(QFrame):
         self.white_name = game.headers.get("White", "White")
         self.black_name = game.headers.get("Black", "Black")
 
-        self.board.board = game.board()
-        self.move_tree = MoveTree(self.board.board)
+        self.move_tree = MoveTree(game.board())
         self._import_variations(game, self.move_tree)
 
         if self.move_tree._main_line:
             self.move_tree._current_move = len(self.move_tree._main_line) - 1
 
-        self.sync_board_to_tree()
+        # Explicitly reset the board's visual state before drawing the
+        # imported position, rather than relying on whatever happened
+        # to be displayed beforehand -- importing is a full state
+        # replacement, not an incremental change, so it shouldn't
+        # depend on correctly diffing against prior state at all.
+        for old_piece in list(self.board.pieces_items.values()):
+            self.board.layout.removeWidget(old_piece)
+            old_piece.deleteLater()
+            old_piece.setParent(None)
+        self.board.pieces_items = {}
+
+        self.board.previous_board = chess.Board(None)
+        self.board.board = self.move_tree.get_board()
+        self.board.uncheck_all()
+        self.board.update_pieces(self.board.board)
+
         self._on_position_changed()
     
     def new_game(self):
@@ -270,6 +284,19 @@ class GameFrame(QFrame):
         self._last_top_moves = []
         self.board.clear_best_move_arrow()
         self.moves_record.render_from_tree(self.move_tree)
+        self.request_eval()
+        self._update_captured_trays()
+
+    def _on_navigated(self):
+        """Call after pure navigation (arrow keys, jump_to_move) --
+        the tree's content hasn't changed, only which move is
+        active, so this uses the lightweight update_active() instead
+        of a full moves-panel rebuild, and clears any leftover piece
+        selection/move-hints and the best-move arrow from before the
+        navigation happened."""
+        self.board.unhighlight_all()
+        self.board.clear_best_move_arrow()
+        self.moves_record.update_active(self.move_tree)
         self.request_eval()
         self._update_captured_trays()
 
@@ -313,7 +340,7 @@ class GameFrame(QFrame):
         node.select_path_to_root()
         self.move_tree = node
         self.sync_board_to_tree()
-        self._on_position_changed()
+        self._on_navigated()
 
     def mousePressEvent(self, event: QMouseEvent):
         global_pos = self.mapToGlobal(event.pos())
@@ -388,14 +415,14 @@ class GameFrame(QFrame):
                         if parent:
                             self.move_tree = parent
 
-                    self._on_position_changed()
+                    self._on_navigated()
                 else:
                     logger.debug("End of variation, moving up to parent line")
                     mama = self.move_tree.move_up()
                     if mama:
                         self.move_tree = mama
                         self.sync_board_to_tree()
-                        self._on_position_changed()
+                        self._on_navigated()
             else:
                 logger.debug("Move stack is empty, nothing to go back to")
 
@@ -408,7 +435,7 @@ class GameFrame(QFrame):
                 self.board.board.push(popped_move)
                 self.board.move_made = True
                 self.board.update_pieces(self.board.board)
-                self._on_position_changed()
+                self._on_navigated()
         
         elif event.key() == Qt.Key.Key_Down:
             child = self.move_tree.move_down()
@@ -416,14 +443,14 @@ class GameFrame(QFrame):
                 child._current_move = 0
                 self.move_tree = child
                 self.sync_board_to_tree()
-                self._on_position_changed()
+                self._on_navigated()
         
         elif event.key() == Qt.Key.Key_Up:
             mama = self.move_tree.move_up()
             if mama:
                 self.move_tree = mama 
                 self.sync_board_to_tree()
-                self._on_position_changed()
+                self._on_navigated()
                 
         elif event.key() == Qt.Key.Key_E:
             self.request_eval()

--- a/chess-game/info.py
+++ b/chess-game/info.py
@@ -9,7 +9,7 @@ from PyQt6.QtWidgets import (
     QGraphicsOpacityEffect,
     QProgressBar,
 )
-from PyQt6.QtGui import QColor, QPainter, QFont, QTextCursor, QFontMetrics
+from PyQt6.QtGui import QColor, QPainter, QFont, QTextCursor, QFontMetrics, QBrush
 from PyQt6.QtCore import Qt, QRect, QObject, QEvent, QTimer, pyqtSignal
 import chess
 import chess.engine
@@ -98,7 +98,34 @@ class MovesRecord(QWidget):
         vbox_layout.setContentsMargins(0, 0, 0, 0)
         self.setLayout(vbox_layout)
 
+    def _find_anchor_range(self, anchor_id):
+        """Find the full [start, end) character range covered by a
+        given anchor's rendered text. Qt's isAnchor()/anchorNames()
+        only reliably tag the first character of a link's text run,
+        but anchorHref() persists correctly across the whole run --
+        so we match on href, and span every consecutive fragment that
+        shares it, not just the first one found."""
+        doc = self.text_edit.document()
+        start = None
+        end = None
+        block = doc.begin()
+        while block.isValid():
+            it = block.begin()
+            while not it.atEnd():
+                frag = it.fragment()
+                fmt = frag.charFormat()
+                if fmt.anchorHref() == anchor_id:
+                    if start is None:
+                        start = frag.position()
+                    end = frag.position() + frag.length()
+                it += 1
+            block = block.next()
+        if start is None:
+            return None
+        return start, end
+
     def render_from_tree(self, move_tree):
+        self.setUpdatesEnabled(False)
         self._targets = {}
         rows = move_tree.get_root().render_table(self._targets)
 
@@ -157,38 +184,73 @@ class MovesRecord(QWidget):
 
         scrollbar.setValue(previous_scroll)
         self._scroll_to_active()
+        self.setUpdatesEnabled(True)
+
+    def update_active(self, move_tree):
+        """Lightweight alternative to render_from_tree() for pure
+        navigation (arrow keys, jump_to_move) -- the tree's actual
+        content hasn't changed, only which move is "active", so we
+        can just restyle the two affected words directly instead of
+        rebuilding the entire document from scratch."""
+        old_anchor = self._active_anchor
+
+        new_anchor = None
+        if move_tree._current_move >= 0:
+            for anchor_id, (node, idx) in self._targets.items():
+                if node is move_tree and idx == move_tree._current_move:
+                    new_anchor = anchor_id
+                    break
+
+        if new_anchor == old_anchor:
+            return
+
+        self._active_anchor = new_anchor
+
+        for anchor_id in (old_anchor, new_anchor):
+            if anchor_id is None:
+                continue
+            found = self._find_anchor_range(anchor_id)
+            if found is None:
+                continue
+            start, end = found
+            cursor = QTextCursor(self.text_edit.document())
+            cursor.setPosition(start)
+            cursor.setPosition(end, QTextCursor.MoveMode.KeepAnchor)
+            fmt = cursor.charFormat()
+            if anchor_id == self._active_anchor:
+                fmt.setBackground(QColor("#0f6e56"))
+                fmt.setForeground(QColor("#eafff6"))
+            else:
+                fmt.setBackground(QBrush(Qt.BrushStyle.NoBrush))
+                fmt.setForeground(QColor("#f6f6f6"))
+            cursor.setCharFormat(fmt)
+
+        self._scroll_to_active()
 
     def _scroll_to_active(self):
         if self._active_anchor is None:
             self.text_edit.verticalScrollBar().setValue(0)
             return
 
-        doc = self.text_edit.document()
-        block = doc.begin()
-        while block.isValid():
-            it = block.begin()
-            while not it.atEnd():
-                frag = it.fragment()
-                fmt = frag.charFormat()
-                if fmt.isAnchor() and self._active_anchor in fmt.anchorNames():
-                    cursor = QTextCursor(doc)
-                    cursor.setPosition(frag.position())
-                    # Trust Qt's own visibility check rather than
-                    # reimplementing it -- ensureCursorVisible() is a
-                    # no-op if the cursor is already visible, so this
-                    # is safe to call unconditionally.
-                    self.text_edit.setTextCursor(cursor)
-                    self.text_edit.ensureCursorVisible()
+        found = self._find_anchor_range(self._active_anchor)
+        if found is None:
+            return
+        start, _ = found
 
-                    # ensureCursorVisible() only scrolls the minimum
-                    # needed, landing the active line right at the
-                    # viewport's edge -- nudge a bit further so it
-                    # settles in with some breathing room instead.
-                    scrollbar = self.text_edit.verticalScrollBar()
-                    scrollbar.setValue(min(scrollbar.value() + 24, scrollbar.maximum()))
-                    return
-                it += 1
-            block = block.next()
+        cursor = QTextCursor(self.text_edit.document())
+        cursor.setPosition(start)
+
+        scrollbar = self.text_edit.verticalScrollBar()
+        before = scrollbar.value()
+
+        self.text_edit.setTextCursor(cursor)
+        self.text_edit.ensureCursorVisible()
+
+        after = scrollbar.value()
+        if after > before:
+            scrollbar.setValue(min(after + 6, scrollbar.maximum()))
+        elif after < before:
+            scrollbar.setValue(max(after - 6, 0))
     
     def _style_for(self, anchor_id):
         styles = ["color:#f6f6f6", "text-decoration:none", "padding:1px 3px", "border-radius:3px"]


### PR DESCRIPTION
Moves-panel flicker (info.py, game.py):

Root cause: every navigation keypress (arrow keys, jump_to_move) was calling render_from_tree(), which rebuilds the entire moves-panel HTML document from scratch via setHtml() -- even though pure navigation never changes the tree's actual content, only which move is "active". This full rebuild is expensive and, especially under rapid repeated keypresses, produced visible flicker as each rebuild interrupted the previous one's rendering before it settled. Several approaches were tried and ruled out along the way: manual visible- range comparisons (became unreliable in long documents), various QTimer/setTextWidth orderings, and setUpdatesEnabled() at both the viewport and outer-widget level -- none addressed the actual cost of rebuilding the whole document on every single keypress.

Fixed with a real architectural split instead of further attempts to mask the symptom:
- render_from_tree() (full rebuild) is now called only when the tree's actual content changes: a new move played, a PGN imported, or a new game started.
- update_active() (new, lightweight) handles pure navigation -- finds the previously-active and newly-active moves and restyles only those two text runs directly via QTextCursor, with no document rebuild at all.
- _find_anchor_range() is a new shared helper both scroll-to-active and update_active rely on. Real bug found here: Qt's isAnchor()/anchorNames() only reliably tag the *first character* of an anchor's rendered text run (confirmed via direct inspection of QTextCharFormat per-fragment), which meant only the first letter of a move was ever being restyled -- but anchorHref() persists correctly across the whole run, so matching on href instead (and spanning every consecutive fragment that shares it) fixes this properly.
- game.py: added _on_navigated(), the navigation-only counterpart to _on_position_changed() -- clears any leftover piece-selection/move- hints and the best-move arrow, calls the new lightweight update_active(), requests a fresh evaluation, and updates the captured-piece trays. Used by all four arrow-key handlers and jump_to_move, replacing what had become a long, repeated block of the same five calls at each site.
- Also fixed: navigating away from a square with move-hints/selection still showing (clicked a piece, then used an arrow key instead of completing the move) left the highlight and hint dots on screen indefinitely -- _on_navigated() now clears these every time.

PGN import board reset (game.py):

Real bug found: playing a manual move and then importing a PGN could leave the manually-moved piece visible alongside the imported position. import_pgn() was assigning self.board.board = game.board() before calling sync_board_to_tree() -- but sync_board_to_tree() relies on capturing whatever's already on self.board.board as previous_board to diff against, so by the time it ran, the "before" state it captured was already the imported game's own starting position, not the true prior on-screen state. Any square that happened to look the same between the imported game's start and end positions (likely for many squares, since most match the standard setup) never got its stale widget cleared.

Fixed by explicitly clearing all piece widgets and resetting previous_board to an empty board before drawing the imported position, rather than relying on a correct diff against whatever was previously true -- importing a PGN is a full state replacement, not an incremental change, and shouldn't depend on diffing logic at all.

Verified manually: navigation in all four directions and via click- to-jump is flicker-free with correct highlighting/scrolling even during rapid repeated keypresses on a long imported game; piece selection and move-hints correctly clear when navigating away instead of completing a move; playing a manual move followed by a PGN import now shows only the imported position with no leftover pieces.