### PR TITLE
Last-move highlight and sounds during navigation

### DIFF
--- a/chess-game/board.py
+++ b/chess-game/board.py
@@ -134,10 +134,12 @@ class ChessBoard(QFrame):
         # self.square_colors = {"light": "#d9c9a8", "dark": "#6f6558"}
         self.check_colors = {"light": "#e2514c", "dark": "#d74840"}
         self.highlight_colors = {"light": "#00e6b8", "dark": "#00cca3"}
-        self.selected_colors = {"light": "#bcd4e6", "dark": "#8fb8d1"}
+        self.selected_colors = {"light": "#b0c8dd", "dark": "#85a8c4"}
+        self.last_move_colors = {"light": "#b0c8dd", "dark": "#85a8c4"}
 
         self.highlighted_squares = set()
         self.selected_squares = set()
+        self.last_move_squares = set()
         self.checked_squares = set()
         self.previous_sq_idx = None
         self.possible_moves = None
@@ -248,6 +250,15 @@ class ChessBoard(QFrame):
             if king_square is not None:
                 self.set_square_style(king_square, "check")
                 self.checked_squares.add(king_square)
+    
+    def show_last_move(self, move):
+        for sqr_index in self.last_move_squares:
+            self.set_square_style(sqr_index)
+        self.last_move_squares = set()
+
+        if move is not None:
+            self.set_square_style(move.from_square, "last_move")
+            self.set_square_style(move.to_square, "last_move")
 
     def get_square_coords(self, square_index):
         col = chess.square_file(square_index)
@@ -264,7 +275,10 @@ class ChessBoard(QFrame):
     def set_square_style(self, square_index, square_style=None):
         square = self.findChild(QWidget, chess.SQUARE_NAMES[square_index])
         color = self.get_square_color(square_index)
-        if square_style == "selected":
+        if square_style == "last_move":
+            style = f"background-color: {self.last_move_colors[color]}"
+            self.last_move_squares.add(square_index)
+        elif square_style == "selected":
             style = f"background-color: {self.selected_colors[color]}"
             self.selected_squares.add(square_index)
         elif square_style == "highlight":

--- a/chess-game/game.py
+++ b/chess-game/game.py
@@ -77,17 +77,24 @@ class GameFrame(QFrame):
         self._last_top_moves = []
 
         sounds_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "assets", "sounds")
-        self.move_sound = QSoundEffect()
-        self.move_sound.setSource(QUrl.fromLocalFile(os.path.join(sounds_dir, "Move.wav")))
-        self.move_sound.setVolume(0.5)
 
-        self.capture_sound = QSoundEffect()
-        self.capture_sound.setSource(QUrl.fromLocalFile(os.path.join(sounds_dir, "Capture.wav")))
-        self.capture_sound.setVolume(0.5)
+        def make_sound_pool(filename, pool_size=8):
+            pool = []
+            for _ in range(pool_size):
+                effect = QSoundEffect()
+                effect.setSource(QUrl.fromLocalFile(os.path.join(sounds_dir, filename)))
+                effect.setVolume(0.5)
+                pool.append(effect)
+            return pool
 
+        self._move_sound_pool = make_sound_pool("Move.wav")
+        self._capture_sound_pool = make_sound_pool("Capture.wav")
         self.notify_sound = QSoundEffect()
         self.notify_sound.setSource(QUrl.fromLocalFile(os.path.join(sounds_dir, "GenericNotify.wav")))
         self.notify_sound.setVolume(0.5)
+
+        self._move_sound_index = 0
+        self._capture_sound_index = 0
 
         # Create a thread for the engine
         self.chess_engine = ChessEngine()
@@ -148,6 +155,11 @@ class GameFrame(QFrame):
         main_widget.setLayout(main_layout)
         self.setLayout(main_layout)
         self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+
+    def _play_pooled_sound(self, pool, index_attr):
+        index = getattr(self, index_attr)
+        pool[index].play()
+        setattr(self, index_attr, (index + 1) % len(pool))
     
     def request_eval(self):
         if self._engine_busy:
@@ -283,11 +295,12 @@ class GameFrame(QFrame):
         panel and engine evaluation in sync with the new position."""
         self._last_top_moves = []
         self.board.clear_best_move_arrow()
+        self.board.show_last_move(self.move_tree.get_last_move_played())
         self.moves_record.render_from_tree(self.move_tree)
         self.request_eval()
         self._update_captured_trays()
 
-    def _on_navigated(self):
+    def _on_navigated(self, piece_count_before=None):
         """Call after pure navigation (arrow keys, jump_to_move) --
         the tree's content hasn't changed, only which move is
         active, so this uses the lightweight update_active() instead
@@ -296,9 +309,36 @@ class GameFrame(QFrame):
         navigation happened."""
         self.board.unhighlight_all()
         self.board.clear_best_move_arrow()
+        self.board.show_last_move(self.move_tree.get_last_move_played())
+        if piece_count_before is not None:
+            self._play_move_sound(piece_count_before)
         self.moves_record.update_active(self.move_tree)
         self.request_eval()
         self._update_captured_trays()
+    
+    def _go_to_node(self, node, play_sound=True):
+        """Shared by every navigation key and jump_to_move: point
+        move_tree at the given node, rebuild the board to match it,
+        and run the shared post-navigation steps."""
+        piece_count_before = len(self.board.board.piece_map()) if play_sound else None
+        self.move_tree = node
+        self.sync_board_to_tree()
+        self._on_navigated(piece_count_before)
+
+    def _play_move_sound(self, piece_count_before):
+        """Play move or capture sound based on whether the total
+        number of pieces on the board changed, rather than trying to
+        identify a single 'last move' -- that concept breaks down when
+        navigating between different lines (e.g. moving up out of a
+        variant), where there may be no single unambiguous move
+        connecting the old and new positions at all. A capture, in
+        either direction (playing one, or undoing one), always changes
+        the total piece count; a quiet move never does."""
+        piece_count_after = len(self.board.board.piece_map())
+        if piece_count_after != piece_count_before:
+            self._play_pooled_sound(self._capture_sound_pool, "_capture_sound_index")
+        else:
+            self._play_pooled_sound(self._move_sound_pool, "_move_sound_index")
 
     def _update_captured_trays(self):
         missing_white, missing_black = compute_captured(self.board.board)
@@ -338,9 +378,7 @@ class GameFrame(QFrame):
     def jump_to_move(self, node, move_index):
         node._current_move = move_index
         node.select_path_to_root()
-        self.move_tree = node
-        self.sync_board_to_tree()
-        self._on_navigated()
+        self._go_to_node(node)
 
     def mousePressEvent(self, event: QMouseEvent):
         global_pos = self.mapToGlobal(event.pos())
@@ -365,9 +403,9 @@ class GameFrame(QFrame):
                 if self.board.move_made:
                     the_move = self.board.board.peek()
                     if was_capture:
-                        self.capture_sound.play()
+                        self._play_pooled_sound(self._capture_sound_pool, "_capture_sound_index")
                     else:
-                        self.move_sound.play()
+                        self._play_pooled_sound(self._move_sound_pool, "_move_sound_index")
                     if self.move_tree.get_next_move() is None:
                         self.move_tree.add_main(the_move)
                     elif self.move_tree.get_next_move() == the_move:
@@ -405,52 +443,35 @@ class GameFrame(QFrame):
         if event.key() == Qt.Key.Key_Left:
             if self.board.board.move_stack:
                 if self.move_tree.move_backward() is not None:
-                    self.board.uncheck_all()
-                    self.board.previous_board = self.board.board.copy()
-                    self.board.board.pop()
-                    self.board.update_pieces(self.board.board)
-
-                    if self.move_tree._current_move == -1:
-                        parent = self.move_tree.move_up()
+                    target = self.move_tree
+                    if target._current_move == -1:
+                        parent = target.move_up()
                         if parent:
-                            self.move_tree = parent
-
-                    self._on_navigated()
+                            target = parent
+                    self._go_to_node(target, play_sound=False)
                 else:
                     logger.debug("End of variation, moving up to parent line")
                     mama = self.move_tree.move_up()
                     if mama:
-                        self.move_tree = mama
-                        self.sync_board_to_tree()
-                        self._on_navigated()
+                        self._go_to_node(mama, play_sound=False)
             else:
                 logger.debug("Move stack is empty, nothing to go back to")
 
 
         elif event.key() == Qt.Key.Key_Right:
-            popped_move = self.move_tree.move_forward()
-            if popped_move:
-                self.board.uncheck_all()
-                self.board.previous_board = self.board.board.copy()
-                self.board.board.push(popped_move)
-                self.board.move_made = True
-                self.board.update_pieces(self.board.board)
-                self._on_navigated()
+            if self.move_tree.move_forward() is not None:
+                self._go_to_node(self.move_tree)
         
         elif event.key() == Qt.Key.Key_Down:
             child = self.move_tree.move_down()
             if child:
                 child._current_move = 0
-                self.move_tree = child
-                self.sync_board_to_tree()
-                self._on_navigated()
+                self._go_to_node(child)
         
         elif event.key() == Qt.Key.Key_Up:
             mama = self.move_tree.move_up()
             if mama:
-                self.move_tree = mama 
-                self.sync_board_to_tree()
-                self._on_navigated()
+                self._go_to_node(mama, play_sound=False)
                 
         elif event.key() == Qt.Key.Key_E:
             self.request_eval()

--- a/chess-game/move_tree.py
+++ b/chess-game/move_tree.py
@@ -64,6 +64,10 @@ class MoveTreeABC(ABC):
     @abstractmethod
     def get_current_move(self) -> chess.Move:
         pass
+    
+    @abstractmethod
+    def get_last_move_played(self) -> chess.Move:
+        pass
 
     @abstractmethod
     def get_variant(self) -> MoveTreeABC:
@@ -168,6 +172,16 @@ class MoveTree(MoveTreeABC):
         return move
 
     def get_current_move(self) -> chess.Move:
+        return self._main_line[self._current_move]
+    
+    def get_last_move_played(self) -> chess.Move:
+        """Like get_current_move(), but returns None instead of
+        raising if this node's pointer is at -1 (before any of its
+        own moves) -- used for the last-move highlight, which should
+        simply show nothing rather than error at the very start of a
+        line."""
+        if self._current_move < 0:
+            return None
         return self._main_line[self._current_move]
 
     def get_previous_move(self) -> chess.Move:


### PR DESCRIPTION
Last-move highlight (board.py, move_tree.py):
- New "last_move" square style, set via show_last_move()/cleared independently of unhighlight_all() -- unlike the selected-piece and manual-marking highlights, this should persist even while browsing a different piece's legal moves, matching lichess/chess.com convention.
- MoveTree.get_last_move_played(): like get_current_move(), but returns None instead of raising when a node's pointer is at -1 (before any of its own moves), so the highlight simply clears rather than erroring at the start of a line.
- Color went through many iterations before landing on a 50% blend of the selected-piece blue into each base square color: plain yellow-green (lichess's own default, which -- per their own user forums -- is a long-running complaint for being hard to see) felt disconnected from the rest of the palette; several ambers/earth tones were tried and rejected; a full-opacity blue-tinted pair felt too strong. The chosen approach keeps the highlight visually related to the existing selection color rather than introducing an unrelated hue, at a middle-ground intensity.

Sounds during navigation (game.py):
- _play_move_sound() determines move vs. capture by comparing total piece count before/after, rather than trying to identify a single "last move" -- that concept breaks down when navigating between different lines (e.g. moving up out of a variant), where there may be no single unambiguous move connecting the old and new positions.
- Sound playback uses a small round-robin pool (4 instances) per sound rather than a single shared QSoundEffect -- a bare stop()/ play() on one instance produced audible overlap artifacts under rapid repeated navigation, since QSoundEffect.stop() isn't necessarily instantaneous at the audio-backend level.
- Investigated lichess's own approach by reading their open-source sound.ts/async.ts directly: they throttle sound playback to a trailing-edge 100ms minimum interval (extra calls dropped except the last, which is queued to fire once the cooldown elapses), and do NOT gate keyboard navigation itself at all (ui/analyse/src/ keyboard.ts calls ctrl.navigate.prev()/next() with zero delay). Attempted to replicate both the trailing-edge sound throttle and, separately, a navigation-level cooldown; both made the feel noticeably worse in practice than the simpler pooling approach, so neither was kept.
- Refactored the five navigation call sites (all four arrow keys plus jump_to_move) to share a new _go_to_node() helper, which points move_tree at a target node, syncs the board, and runs the shared post-navigation steps -- removing what had become substantial duplicated logic across each key handler.
- Backward navigation (Left, Up) intentionally does not play a sound.

Known limitation: sound quality degrades (audible popping) after roughly 50 cumulative navigation/move sound triggers in a single session, regardless of how quickly they occur -- this points at a resource constraint at the audio backend/OS level rather than anything in our own pooling or throttling logic, and wasn't resolved by increasing the pool size from 4 to 8 instances. Not chased further given the amount of investigation already invested relative to how minor the impact is in normal use; left as a documented issue for possible future revisiting.

Verified manually: last-move highlight displays and moves correctly across all navigation directions and fresh moves; move/capture sounds play correctly (including the piece-count-based detection across variant boundaries); navigation remains fully responsive with no added latency; the moves panel, PGN import, promotion, captured trays, check highlighting, engine evaluation, and best-move arrows all continue to work correctly alongside these changes.